### PR TITLE
feat(chat): Polly TTS 음성 캐싱 및 DynamoDB 최적화 refs #8

### DIFF
--- a/chatting/ChatFunction/build.gradle
+++ b/chatting/ChatFunction/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     // JSON Processing
     implementation 'com.google.code.gson:gson:2.10.1'
 
+    // Password Hashing
+    implementation 'org.mindrot:jbcrypt:0.4'
+
     // Logging
     implementation 'com.amazonaws:aws-lambda-java-log4j2:1.6.0'
     implementation 'org.apache.logging.log4j:log4j-api:2.22.1'

--- a/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/handler/ChatMessageHandler.java
+++ b/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/handler/ChatMessageHandler.java
@@ -77,6 +77,8 @@ public class ChatMessageHandler implements RequestHandler<APIGatewayProxyRequest
                 .sk("MSG#" + now + "#" + messageId)
                 .gsi1pk("USER#" + userId)
                 .gsi1sk("MSG#" + now)
+                .gsi2pk("MSG#" + messageId)        // GSI2: messageId로 직접 조회용
+                .gsi2sk("ROOM#" + roomId)
                 .messageId(messageId)
                 .roomId(roomId)
                 .userId(userId)
@@ -87,11 +89,8 @@ public class ChatMessageHandler implements RequestHandler<APIGatewayProxyRequest
 
         ChatMessage savedMessage = chatMessageService.saveMessage(message);
 
-        // 채팅방 lastMessageAt 업데이트
-        chatRoomRepository.findById(roomId).ifPresent(room -> {
-            room.setLastMessageAt(now);
-            chatRoomRepository.save(room);
-        });
+        // 채팅방 lastMessageAt 업데이트 (UpdateExpression으로 1회 호출)
+        chatRoomRepository.updateLastMessageAt(roomId, now);
 
         logger.info("Message sent: {} in room: {}", messageId, roomId);
         return createResponse(201, ApiResponse.success("Message sent", savedMessage));

--- a/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/handler/ChatVoiceHandler.java
+++ b/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/handler/ChatVoiceHandler.java
@@ -7,11 +7,15 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.chatting.dto.ApiResponse;
+import com.mzc.secondproject.serverless.chatting.model.ChatMessage;
+import com.mzc.secondproject.serverless.chatting.repository.ChatMessageRepository;
 import com.mzc.secondproject.serverless.chatting.service.PollyService;
+import com.mzc.secondproject.serverless.chatting.service.PollyService.VoiceSynthesisResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
@@ -19,9 +23,11 @@ public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEv
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final PollyService pollyService;
+    private final ChatMessageRepository messageRepository;
 
     public ChatVoiceHandler() {
         this.pollyService = new PollyService();
+        this.messageRepository = new ChatMessageRepository();
     }
 
     @Override
@@ -35,16 +41,61 @@ public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEv
 
             String body = request.getBody();
             Map<String, String> requestBody = gson.fromJson(body, Map.class);
-            String text = requestBody.get("text");
+            String messageId = requestBody.get("messageId");
+            String roomId = requestBody.get("roomId");
             String voice = requestBody.getOrDefault("voice", "FEMALE");
 
-            if (text == null || text.isEmpty()) {
-                return createResponse(400, ApiResponse.error("text is required"));
+            if (messageId == null || messageId.isEmpty()) {
+                return createResponse(400, ApiResponse.error("messageId is required"));
+            }
+            if (roomId == null || roomId.isEmpty()) {
+                return createResponse(400, ApiResponse.error("roomId is required"));
             }
 
-            String audioUrl = pollyService.synthesizeSpeech(text, voice);
+            // 메시지 조회
+            Optional<ChatMessage> messageOpt = messageRepository.findByRoomIdAndMessageId(roomId, messageId);
+            if (messageOpt.isEmpty()) {
+                return createResponse(404, ApiResponse.error("Message not found"));
+            }
 
-            return createResponse(200, ApiResponse.success("Speech synthesized", Map.of("audioUrl", audioUrl)));
+            ChatMessage message = messageOpt.get();
+            boolean isMale = "MALE".equalsIgnoreCase(voice);
+
+            // 캐시된 음성 키 확인
+            String cachedKey = isMale ? message.getMaleVoiceKey() : message.getFemaleVoiceKey();
+
+            String audioUrl;
+            boolean cached;
+
+            if (cachedKey != null && !cachedKey.isEmpty()) {
+                // 캐시 히트: DynamoDB에 키가 있으면 S3에서 URL 생성
+                logger.info("DB cache hit for message: {}, voice: {}", messageId, voice);
+                audioUrl = pollyService.getPresignedUrl(cachedKey);
+                cached = true;
+            } else {
+                // 캐시 미스: Polly 변환 → S3 저장 → DynamoDB 업데이트
+                VoiceSynthesisResult result = pollyService.synthesizeSpeechForMessage(
+                        messageId, message.getContent(), voice);
+
+                // DynamoDB에 S3 키 저장
+                if (isMale) {
+                    message.setMaleVoiceKey(result.getS3Key());
+                } else {
+                    message.setFemaleVoiceKey(result.getS3Key());
+                }
+                messageRepository.save(message);
+
+                audioUrl = result.getAudioUrl();
+                cached = result.isCached();
+            }
+
+            return createResponse(200, ApiResponse.success(
+                    cached ? "Speech retrieved from cache" : "Speech synthesized",
+                    Map.of(
+                            "audioUrl", audioUrl,
+                            "cached", cached
+                    )
+            ));
 
         } catch (Exception e) {
             logger.error("Error synthesizing speech", e);

--- a/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/model/ChatMessage.java
+++ b/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/model/ChatMessage.java
@@ -22,6 +22,8 @@ public class ChatMessage {
     private String sk;          // MSG#{timestamp}#{messageId}
     private String gsi1pk;      // USER#{userId}
     private String gsi1sk;      // MSG#{timestamp}
+    private String gsi2pk;      // MSG#{messageId} - messageId로 직접 조회용
+    private String gsi2sk;      // ROOM#{roomId}
 
     private String messageId;
     private String roomId;
@@ -30,6 +32,10 @@ public class ChatMessage {
     private String messageType; // TEXT, IMAGE, VOICE, AI_RESPONSE
     private String createdAt;
     private Long ttl;
+
+    // 음성 캐시용 S3 키 (voice/{messageId}_{voice}.mp3)
+    private String maleVoiceKey;
+    private String femaleVoiceKey;
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute("PK")
@@ -53,5 +59,17 @@ public class ChatMessage {
     @DynamoDbAttribute("GSI1SK")
     public String getGsi1sk() {
         return gsi1sk;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "GSI2")
+    @DynamoDbAttribute("GSI2PK")
+    public String getGsi2pk() {
+        return gsi2pk;
+    }
+
+    @DynamoDbSecondarySortKey(indexNames = "GSI2")
+    @DynamoDbAttribute("GSI2SK")
+    public String getGsi2sk() {
+        return gsi2sk;
     }
 }

--- a/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/service/ChatMessageService.java
+++ b/chatting/ChatFunction/src/main/java/com/mzc/secondproject/serverless/chatting/service/ChatMessageService.java
@@ -33,8 +33,8 @@ public class ChatMessageService {
         return repository.findByRoomIdWithPagination(roomId, limit, cursor);
     }
 
-    public List<ChatMessage> getMessagesByUser(String userId) {
-        logger.info("Getting messages for user: {}", userId);
-        return repository.findByUserId(userId);
+    public ChatMessageRepository.MessagePage getMessagesByUserWithPagination(String userId, int limit, String cursor) {
+        logger.info("Getting messages for user: {} with limit: {}", userId, limit);
+        return repository.findByUserIdWithPagination(userId, limit, cursor);
     }
 }

--- a/chatting/template.yaml
+++ b/chatting/template.yaml
@@ -158,6 +158,8 @@ Resources:
       SnapStart:
         ApplyOn: PublishedVersions
       Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref ChatTable
         - S3CrudPolicy:
             BucketName: group2-englishstudy
         - Statement:
@@ -206,6 +208,10 @@ Resources:
           AttributeType: S
         - AttributeName: GSI1SK
           AttributeType: S
+        - AttributeName: GSI2PK
+          AttributeType: S
+        - AttributeName: GSI2SK
+          AttributeType: S
       KeySchema:
         - AttributeName: PK
           KeyType: HASH
@@ -217,6 +223,14 @@ Resources:
             - AttributeName: GSI1PK
               KeyType: HASH
             - AttributeName: GSI1SK
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: GSI2
+          KeySchema:
+            - AttributeName: GSI2PK
+              KeyType: HASH
+            - AttributeName: GSI2SK
               KeyType: RANGE
           Projection:
             ProjectionType: ALL


### PR DESCRIPTION
## 목적
- 동일 메시지 음성 변환 시 Polly 재호출 방지로 비용 절감 및 응답 속도 개선
- DynamoDB 풀스캔 방지 및 쿼리 최적화
- 관련 Story: #8
- 관련 Epic: #7

## 변경 요약
### 핵심 변경
- 메시지별 음성 S3 키 캐싱 (maleVoiceKey, femaleVoiceKey)
- GSI2 추가로 messageId 직접 조회
- BCrypt 비밀번호 해싱
- DynamoDbClient Singleton 패턴

### 주요 파일/모듈
- `ChatMessage.java` - gsi2pk, gsi2sk, voiceKey 필드 추가
- `ChatMessageRepository.java` - GSI2 조회, 페이지네이션
- `ChatRoomRepository.java` - updateLastMessageAt (N+1 해결)
- `ChatVoiceHandler.java` - 캐싱 로직
- `PollyService.java` - 캐싱 로직
- `template.yaml` - GSI2, DynamoDB 권한

## 수용 기준 검증
- [x] 메시지별 음성 데이터(S3 키)를 DynamoDB에 저장
- [x] 남성/여성 음성 각각 캐싱 (maleVoiceKey, femaleVoiceKey)
- [x] 캐시 히트 시 Polly 호출 없이 S3 Pre-signed URL 반환
- [x] API 요청 형식 변경 (text → messageId, roomId)
- [x] 응답에 캐시 여부(cached) 포함
- [x] 빌드/린트 통과

## 브레이킹/마이그레이션
### API 변경 (프론트엔드 수정 필요)
```
POST /chat/voice/synthesize

[기존] { "text": "Hello", "voice": "FEMALE" }
[변경] { "messageId": "xxx", "roomId": "yyy", "voice": "FEMALE" }
```

### 스키마 변경
- DynamoDB GSI2 추가 (GSI2PK, GSI2SK)
- ChatMessage에 maleVoiceKey, femaleVoiceKey 필드 추가
- 기존 데이터 호환성 유지 (nullable 필드)

## 테스트
- [x] 빌드 통과
- [ ] 배포 후 음성 캐싱 동작 확인
- [ ] 캐시 히트/미스 로그 확인

## 참조
Closes #9
Closes #8
refs #7