### PR TITLE
perf: BatchGetItem 적용으로 N+1 문제 해결

### DIFF
--- a/vocabulary/VocabFunction/src/main/java/com/mzc/secondproject/serverless/vocabulary/handler/DailyStudyHandler.java
+++ b/vocabulary/VocabFunction/src/main/java/com/mzc/secondproject/serverless/vocabulary/handler/DailyStudyHandler.java
@@ -169,11 +169,8 @@ public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestE
             return new ArrayList<>();
         }
 
-        List<Word> words = new ArrayList<>();
-        for (String wordId : wordIds) {
-            wordRepository.findById(wordId).ifPresent(words::add);
-        }
-        return words;
+        // BatchGetItem으로 한 번에 조회 (N+1 문제 해결)
+        return wordRepository.findByIds(wordIds);
     }
 
     private Map<String, Object> calculateProgress(DailyStudy dailyStudy) {


### PR DESCRIPTION
## Summary
- WordRepository에 `findByIds()` 메서드 추가 (BatchGetItem 사용)
- DailyStudyHandler N+1 문제 해결
- TestHandler N+1 문제 해결 (startTest, submitAnswer)

## Performance Improvement
| 시나리오 | 변경 전 | 변경 후 | 개선 |
|----------|---------|---------|------|
| 55개 단어 조회 | 55 GetItem 호출 | 1 BatchGetItem 호출 | 98% 감소 |
| 시험 제출 (50문제) | 50 GetItem 호출 | 1 BatchGetItem 호출 | 98% 감소 |

## Test plan
- [x] SAM 빌드 성공 확인
- [x] 로컬 테스트
- [x] 배포 후 API 테스트

## Related Issues
- Closes #38