### PR TITLE
feat: 나의 단어장 필터링 기능 추가

### DIFF
--- a/vocabulary/VocabFunction/src/main/java/com/mzc/secondproject/serverless/vocabulary/handler/UserWordHandler.java
+++ b/vocabulary/VocabFunction/src/main/java/com/mzc/secondproject/serverless/vocabulary/handler/UserWordHandler.java
@@ -72,6 +72,8 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         String userId = pathParams != null ? pathParams.get("userId") : null;
         String status = queryParams != null ? queryParams.get("status") : null;
         String cursor = queryParams != null ? queryParams.get("cursor") : null;
+        String bookmarked = queryParams != null ? queryParams.get("bookmarked") : null;
+        String incorrectOnly = queryParams != null ? queryParams.get("incorrectOnly") : null;
 
         if (userId == null) {
             return createResponse(400, ApiResponse.error("userId is required"));
@@ -83,7 +85,13 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         }
 
         UserWordRepository.UserWordPage userWordPage;
-        if (status != null && !status.isEmpty()) {
+
+        // 필터 우선순위: bookmarked > incorrectOnly > status > 전체
+        if ("true".equalsIgnoreCase(bookmarked)) {
+            userWordPage = userWordRepository.findBookmarkedWords(userId, limit, cursor);
+        } else if ("true".equalsIgnoreCase(incorrectOnly)) {
+            userWordPage = userWordRepository.findIncorrectWords(userId, limit, cursor);
+        } else if (status != null && !status.isEmpty()) {
             userWordPage = userWordRepository.findByUserIdAndStatus(userId, status, limit, cursor);
         } else {
             userWordPage = userWordRepository.findByUserIdWithPagination(userId, limit, cursor);


### PR DESCRIPTION
## Summary
- 북마크한 단어만 조회: `?bookmarked=true`
- 틀린 적 있는 단어만 조회: `?incorrectOnly=true`
- FilterExpression 사용으로 GSI 추가 없이 DynamoDB 비용 최적화

## API 사용법
```
# 북마크한 단어
GET /vocab/users/{userId}/words?bookmarked=true

# 틀린 단어
GET /vocab/users/{userId}/words?incorrectOnly=true

# 상태별 (기존)
GET /vocab/users/{userId}/words?status=LEARNING
```

## 비용 최적화
- ❌ GSI 추가 (쓰기 비용 2배 증가)
- ✅ FilterExpression 사용 (추가 비용 없음)

## Related Issue
Closes #51