### PR TITLE
refactor: Handler들 createResponse를 ResponseUtil로 통일 (#60)

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatAIHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatAIHandler.java
@@ -4,9 +4,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.chatting.service.BedrockService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +15,6 @@ import java.util.Map;
 public class ChatAIHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(ChatAIHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final BedrockService bedrockService;
 
@@ -44,17 +42,5 @@ public class ChatAIHandler implements RequestHandler<APIGatewayProxyRequestEvent
             logger.error("Error generating AI response", e);
             return createResponse(500, ApiResponse.error("Internal server error: " + e.getMessage()));
         }
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatMessageHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatMessageHandler.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import com.mzc.secondproject.serverless.common.util.ResponseUtil;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatMessage;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
 import com.mzc.secondproject.serverless.domain.chatting.repository.ChatMessageRepository;
@@ -24,7 +24,6 @@ import java.util.UUID;
 public class ChatMessageHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(ChatMessageHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final ChatMessageService chatMessageService;
     private final ChatRoomRepository chatRoomRepository;
@@ -59,7 +58,7 @@ public class ChatMessageHandler implements RequestHandler<APIGatewayProxyRequest
         }
 
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         String userId = (String) requestBody.get("userId");
         String content = (String) requestBody.get("content");
@@ -136,17 +135,5 @@ public class ChatMessageHandler implements RequestHandler<APIGatewayProxyRequest
         result.put("hasMore", messagePage.hasMore());
 
         return createResponse(200, ApiResponse.success("Messages retrieved", result));
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatRoomHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatRoomHandler.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import com.mzc.secondproject.serverless.common.util.ResponseUtil;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
 import com.mzc.secondproject.serverless.domain.chatting.repository.ChatRoomRepository;
 import org.mindrot.jbcrypt.BCrypt;
@@ -24,7 +24,6 @@ import java.util.UUID;
 public class ChatRoomHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(ChatRoomHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final ChatRoomRepository roomRepository;
 
@@ -80,7 +79,7 @@ public class ChatRoomHandler implements RequestHandler<APIGatewayProxyRequestEve
 
     private APIGatewayProxyResponseEvent createRoom(APIGatewayProxyRequestEvent request) {
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         String name = (String) requestBody.get("name");
         String description = (String) requestBody.get("description");
@@ -189,7 +188,7 @@ public class ChatRoomHandler implements RequestHandler<APIGatewayProxyRequestEve
         String roomId = pathParams != null ? pathParams.get("roomId") : null;
 
         String body = request.getBody();
-        Map<String, String> requestBody = gson.fromJson(body, Map.class);
+        Map<String, String> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
         String userId = requestBody.get("userId");
         String password = requestBody.get("password");
 
@@ -241,7 +240,7 @@ public class ChatRoomHandler implements RequestHandler<APIGatewayProxyRequestEve
         String roomId = pathParams != null ? pathParams.get("roomId") : null;
 
         String body = request.getBody();
-        Map<String, String> requestBody = gson.fromJson(body, Map.class);
+        Map<String, String> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
         String userId = requestBody.get("userId");
 
         if (roomId == null || userId == null) {
@@ -304,17 +303,5 @@ public class ChatRoomHandler implements RequestHandler<APIGatewayProxyRequestEve
         logger.info("Deleted room: {} by owner: {}", roomId, userId);
 
         return createResponse(200, ApiResponse.success("Room deleted", null));
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatVoiceHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatVoiceHandler.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import com.mzc.secondproject.serverless.common.util.ResponseUtil;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatMessage;
 import com.mzc.secondproject.serverless.domain.chatting.repository.ChatMessageRepository;
 import com.mzc.secondproject.serverless.domain.chatting.service.PollyService;
@@ -20,7 +20,6 @@ import java.util.Optional;
 public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(ChatVoiceHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final PollyService pollyService;
     private final ChatMessageRepository messageRepository;
@@ -40,7 +39,7 @@ public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEv
             }
 
             String body = request.getBody();
-            Map<String, String> requestBody = gson.fromJson(body, Map.class);
+            Map<String, String> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
             String messageId = requestBody.get("messageId");
             String roomId = requestBody.get("roomId");
             String voice = requestBody.getOrDefault("voice", "FEMALE");
@@ -101,17 +100,5 @@ public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEv
             logger.error("Error synthesizing speech", e);
             return createResponse(500, ApiResponse.error("Internal server error: " + e.getMessage()));
         }
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/DailyStudyHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/DailyStudyHandler.java
@@ -4,9 +4,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.DailyStudy;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.UserWord;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
@@ -28,7 +27,6 @@ import java.util.stream.Collectors;
 public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(DailyStudyHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private static final int NEW_WORDS_COUNT = 50;
     private static final int REVIEW_WORDS_COUNT = 5;
@@ -237,17 +235,5 @@ public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestE
 
         logger.info("Marked word as learned: userId={}, wordId={}", userId, wordId);
         return createResponse(200, ApiResponse.success("Word marked as learned", calculateProgress(updatedDailyStudy)));
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatisticsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatisticsHandler.java
@@ -3,8 +3,7 @@ package com.mzc.secondproject.serverless.domain.vocabulary.handler;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.mzc.secondproject.serverless.common.util.ResponseUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.UserWord;
 import com.mzc.secondproject.serverless.domain.vocabulary.repository.UserWordRepository;
 import org.slf4j.Logger;
@@ -23,7 +22,6 @@ import java.util.Optional;
 public class StatisticsHandler implements RequestHandler<SQSEvent, Void> {
 
     private static final Logger logger = LoggerFactory.getLogger(StatisticsHandler.class);
-    private static final Gson gson = new GsonBuilder().create();
 
     private final UserWordRepository userWordRepository;
 
@@ -53,7 +51,7 @@ public class StatisticsHandler implements RequestHandler<SQSEvent, Void> {
         String body = message.getBody();
         logger.info("Processing message: {}", body);
 
-        Map<String, Object> testResult = gson.fromJson(body, Map.class);
+        Map<String, Object> testResult = ResponseUtil.gson().fromJson(body, Map.class);
 
         String userId = (String) testResult.get("userId");
         List<Map<String, Object>> results = (List<Map<String, Object>>) testResult.get("results");

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatsHandler.java
@@ -4,9 +4,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.DailyStudy;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.TestResult;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.UserWord;
@@ -28,7 +27,6 @@ import java.util.stream.Collectors;
 public class StatsHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(StatsHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final UserWordRepository userWordRepository;
     private final DailyStudyRepository dailyStudyRepository;
@@ -324,17 +322,5 @@ public class StatsHandler implements RequestHandler<APIGatewayProxyRequestEvent,
         result.put("suggestions", suggestions);
 
         return createResponse(200, ApiResponse.success("Weakness analysis completed", result));
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/UserWordHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/UserWordHandler.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import com.mzc.secondproject.serverless.common.util.ResponseUtil;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.UserWord;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
 import com.mzc.secondproject.serverless.domain.vocabulary.repository.UserWordRepository;
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(UserWordHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final UserWordRepository userWordRepository;
     private final WordRepository wordRepository;
@@ -143,7 +142,7 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         }
 
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         // 정답/오답 여부
         Boolean isCorrect = (Boolean) requestBody.get("isCorrect");
@@ -204,7 +203,7 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         }
 
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         Optional<UserWord> optUserWord = userWordRepository.findByUserIdAndWordId(userId, wordId);
         UserWord userWord;
@@ -355,17 +354,5 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         }
 
         return enrichedList;
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/VoiceHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/VoiceHandler.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import com.mzc.secondproject.serverless.common.util.ResponseUtil;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
 import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordRepository;
 import com.mzc.secondproject.serverless.domain.vocabulary.service.PollyService;
@@ -20,7 +20,6 @@ import java.util.Optional;
 public class VoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(VoiceHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final WordRepository wordRepository;
     private final PollyService pollyService;
@@ -53,7 +52,7 @@ public class VoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent,
 
     private APIGatewayProxyResponseEvent synthesizeSpeech(APIGatewayProxyRequestEvent request) {
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         String wordId = (String) requestBody.get("wordId");
         String voice = (String) requestBody.getOrDefault("voice", "FEMALE");
@@ -107,17 +106,5 @@ public class VoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent,
         responseData.put("cached", cached);
 
         return createResponse(200, ApiResponse.success("Speech synthesized", responseData));
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/WordHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/WordHandler.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.mzc.secondproject.serverless.common.dto.ApiResponse;
+import com.mzc.secondproject.serverless.common.util.ResponseUtil;
+import static com.mzc.secondproject.serverless.common.util.ResponseUtil.createResponse;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
 import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordRepository;
 import org.slf4j.Logger;
@@ -23,7 +23,6 @@ import java.util.UUID;
 public class WordHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger logger = LoggerFactory.getLogger(WordHandler.class);
-    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     private final WordRepository wordRepository;
 
@@ -84,7 +83,7 @@ public class WordHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 
     private APIGatewayProxyResponseEvent createWord(APIGatewayProxyRequestEvent request) {
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         String english = (String) requestBody.get("english");
         String korean = (String) requestBody.get("korean");
@@ -185,7 +184,7 @@ public class WordHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 
         Word word = optWord.get();
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         if (requestBody.containsKey("english")) {
             word.setEnglish((String) requestBody.get("english"));
@@ -235,7 +234,7 @@ public class WordHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
     @SuppressWarnings("unchecked")
     private APIGatewayProxyResponseEvent createWordsBatch(APIGatewayProxyRequestEvent request) {
         String body = request.getBody();
-        Map<String, Object> requestBody = gson.fromJson(body, Map.class);
+        Map<String, Object> requestBody = ResponseUtil.gson().fromJson(body, Map.class);
 
         List<Map<String, Object>> wordsList = (List<Map<String, Object>>) requestBody.get("words");
         if (wordsList == null || wordsList.isEmpty()) {
@@ -321,17 +320,5 @@ public class WordHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
         result.put("hasMore", wordPage.hasMore());
 
         return createResponse(200, ApiResponse.success("Search completed", result));
-    }
-
-    private APIGatewayProxyResponseEvent createResponse(int statusCode, Object body) {
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(statusCode)
-                .withHeaders(Map.of(
-                        "Content-Type", "application/json",
-                        "Access-Control-Allow-Origin", "*",
-                        "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS",
-                        "Access-Control-Allow-Headers", "Content-Type,Authorization"
-                ))
-                .withBody(gson.toJson(body));
     }
 }


### PR DESCRIPTION
## Summary
- 11개 Handler의 중복 `createResponse` 메서드 제거
- `ResponseUtil.createResponse()` static import로 대체
- 중복 Gson 인스턴스 제거 → `ResponseUtil.gson()` 사용

## 변경 파일
- ChatAIHandler
- ChatMessageHandler
- ChatRoomHandler
- ChatVoiceHandler
- DailyStudyHandler
- StatisticsHandler
- StatsHandler
- TestHandler
- UserWordHandler
- VoiceHandler
- WordHandler

## Test plan
- [x] 빌드 성공 확인

Closes #60