### PR TITLE
build: JaCoCo 테스트 커버리지 설정 (#66)

### DIFF
--- a/ServerlessFunction/build.gradle
+++ b/ServerlessFunction/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'groovy'
+    id 'jacoco'
 }
 
 group = 'com.mzc.secondproject.serverless'
@@ -57,6 +58,19 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }
 
 task buildZip(type: Zip) {


### PR DESCRIPTION
## Summary
- JaCoCo 플러그인 추가
- 테스트 커버리지 리포트 설정 (HTML, XML)
- 테스트 실행 시 자동으로 커버리지 리포트 생성

## 사용법
```bash
./gradlew test jacocoTestReport
```
리포트 위치: `build/reports/jacoco/test/html/index.html`

## Test plan
- [x] ./gradlew test jacocoTestReport 실행 확인
- [ ] 테스트 코드 추가 후 리포트 생성 확인

## Related Issue
Closes #66