### PR TITLE
feat(vocabulary): Story #40 학습 보조 기능 API 추가

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/dto/request/BatchGetWordsRequest.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/dto/request/BatchGetWordsRequest.java
@@ -1,0 +1,15 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.dto.request;
+
+import java.util.List;
+
+public class BatchGetWordsRequest {
+    private List<String> wordIds;
+
+    public List<String> getWordIds() {
+        return wordIds;
+    }
+
+    public void setWordIds(List<String> wordIds) {
+        this.wordIds = wordIds;
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestQueryService.java
@@ -2,9 +2,14 @@ package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.TestResult;
+import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
 import com.mzc.secondproject.serverless.domain.vocabulary.repository.TestResultRepository;
+import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Test 조회 전용 서비스 (CQRS Query)
@@ -14,12 +19,33 @@ public class TestQueryService {
     private static final Logger logger = LoggerFactory.getLogger(TestQueryService.class);
 
     private final TestResultRepository testResultRepository;
+    private final WordRepository wordRepository;
 
     public TestQueryService() {
         this.testResultRepository = new TestResultRepository();
+        this.wordRepository = new WordRepository();
     }
 
     public PaginatedResult<TestResult> getTestResults(String userId, int limit, String cursor) {
         return testResultRepository.findByUserIdWithPagination(userId, limit, cursor);
     }
+
+    public Optional<TestResultDetail> getTestResultDetail(String userId, String testId) {
+        Optional<TestResult> optResult = testResultRepository.findByUserIdAndTestId(userId, testId);
+
+        if (optResult.isEmpty()) {
+            return Optional.empty();
+        }
+
+        TestResult testResult = optResult.get();
+        List<Word> incorrectWords = List.of();
+
+        if (testResult.getIncorrectWordIds() != null && !testResult.getIncorrectWordIds().isEmpty()) {
+            incorrectWords = wordRepository.findByIds(testResult.getIncorrectWordIds());
+        }
+
+        return Optional.of(new TestResultDetail(testResult, incorrectWords));
+    }
+
+    public record TestResultDetail(TestResult testResult, List<Word> incorrectWords) {}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordQueryService.java
@@ -6,6 +6,7 @@ import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordReposit
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -36,5 +37,9 @@ public class WordQueryService {
 
     public PaginatedResult<Word> searchWords(String query, int limit, String cursor) {
         return wordRepository.searchByKeyword(query, limit, cursor);
+    }
+
+    public List<Word> getWordsByIds(List<String> wordIds) {
+        return wordRepository.findByIds(wordIds);
     }
 }

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -217,6 +217,12 @@ Resources:
             RestApiId: !Ref MainApi
             Path: /vocab/words/batch
             Method: POST
+        BatchGetWords:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /vocab/words/batch/get
+            Method: POST
         SearchWords:
           Type: Api
           Properties:
@@ -342,11 +348,17 @@ Resources:
             RestApiId: !Ref MainApi
             Path: /vocab/test/{userId}/submit
             Method: POST
-        GetTestResult:
+        GetTestResults:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
             Path: /vocab/test/{userId}/results
+            Method: GET
+        GetTestResultDetail:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /vocab/test/{userId}/results/{testId}
             Method: GET
 
   StatsFunction:


### PR DESCRIPTION
## Summary
Story #40 학습 보조 기능 구현

### 완료된 Task
- 단어 배치 조회 API (`POST /vocab/words/batch/get`) - closes #134
- 특정 날짜 학습 단어 조회 (`GET /vocab/daily/{userId}?date=`) - closes #135
- 시험 결과 상세 조회 (`GET /vocab/test/{userId}/results/{testId}`) - closes #136
- 오답 노트 API (`GET /vocab/users/{userId}/wrong-answers`) - closes #138
- 커스텀 단어장 그룹 CRUD (`/vocab/users/{userId}/groups/*`) - closes #139

### 미구현 (추후 진행)
- EventBridge 일일 학습 알림

## 신규 API 목록
| Method | Path | 설명 |
|--------|------|------|
| POST | /vocab/words/batch/get | 단어 배치 조회 |
| GET | /vocab/daily/{userId}?date= | 특정 날짜 학습 조회 |
| GET | /vocab/test/{userId}/results/{testId} | 시험 결과 상세 |
| GET | /vocab/users/{userId}/wrong-answers | 오답 노트 |
| POST | /vocab/users/{userId}/groups | 그룹 생성 |
| GET | /vocab/users/{userId}/groups | 그룹 목록 |
| GET | /vocab/users/{userId}/groups/{groupId} | 그룹 상세 |
| PUT | /vocab/users/{userId}/groups/{groupId} | 그룹 수정 |
| DELETE | /vocab/users/{userId}/groups/{groupId} | 그룹 삭제 |
| POST | /vocab/users/{userId}/groups/{groupId}/words/{wordId} | 단어 추가 |
| DELETE | /vocab/users/{userId}/groups/{groupId}/words/{wordId} | 단어 제거 |

## Test plan
- [ ] 단어 배치 조회 테스트
- [ ] 특정 날짜 학습 조회 테스트
- [ ] 시험 결과 상세 조회 테스트
- [ ] 오답 노트 조회 테스트
- [ ] 커스텀 단어장 그룹 CRUD 테스트

refs #40