### PR TITLE
[Story #17] 단어/예문 개별 음성 재생 기능

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/dto/request/SynthesizeVoiceRequest.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/dto/request/SynthesizeVoiceRequest.java
@@ -12,5 +12,7 @@ import lombok.NoArgsConstructor;
 public class SynthesizeVoiceRequest {
     private String wordId;
     @Builder.Default
-    private String voice = "FEMALE";
+    private String voice = "FEMALE";  // MALE 또는 FEMALE
+    @Builder.Default
+    private String type = "WORD";     // WORD 또는 EXAMPLE
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/model/Word.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/model/Word.java
@@ -41,9 +41,13 @@ public class Word {
     private String createdAt;
     private Long ttl;
 
-    // 음성 캐시용 S3 키 (vocab/voice/{wordId}_{voice}.mp3)
+    // 단어 음성 캐시용 S3 키 (vocab/voice/{wordId}_{voice}.mp3)
     private String maleVoiceKey;
     private String femaleVoiceKey;
+
+    // 예문 음성 캐시용 S3 키 (vocab/voice/{wordId}_{voice}_example.mp3)
+    private String maleExampleVoiceKey;
+    private String femaleExampleVoiceKey;
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute("PK")


### PR DESCRIPTION
## Summary
- Word 모델에 예문 음성 캐시 필드 추가 (maleExampleVoiceKey, femaleExampleVoiceKey)
- SynthesizeVoiceRequest에 type 파라미터 추가 (WORD/EXAMPLE)
- VoiceHandler에서 type에 따른 음성 합성 분기 처리

## Changes
- `Word.java`: 예문 음성 캐시 S3 키 필드 추가
- `SynthesizeVoiceRequest.java`: type 필드 추가 (기본값: WORD)
- `VoiceHandler.java`: 단어/예문 개별 음성 합성 지원

## API 사용법
```json
POST /vocab/voice/synthesize
{
  "wordId": "xxx",
  "voice": "FEMALE",  // MALE 또는 FEMALE
  "type": "WORD"      // WORD 또는 EXAMPLE
}
```

## Test plan
- [ ] 단어 음성 합성 테스트 (type=WORD)
- [ ] 예문 음성 합성 테스트 (type=EXAMPLE)
- [ ] 예문이 없는 단어에 예문 음성 요청 시 400 에러 확인
- [ ] 남성/여성 음성 모두 테스트
- [ ] 캐싱 동작 확인

refs #17, #141