### PR TITLE
feat(chatting): 실시간 메시지 전송 구현 refs #145

### DIFF
--- a/ServerlessFunction/build.gradle
+++ b/ServerlessFunction/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'software.amazon.awssdk:polly'
     implementation 'software.amazon.awssdk:sns'
     implementation 'software.amazon.awssdk:bedrockruntime'
+    implementation 'software.amazon.awssdk:apigatewaymanagementapi'
 
     // JSON Processing
     implementation 'com.google.code.gson:gson:2.10.1'

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/WebSocketBroadcaster.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/WebSocketBroadcaster.java
@@ -1,0 +1,83 @@
+package com.mzc.secondproject.serverless.common.util;
+
+import com.mzc.secondproject.serverless.common.config.WebSocketConfig;
+import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.apigatewaymanagementapi.ApiGatewayManagementApiClient;
+import software.amazon.awssdk.services.apigatewaymanagementapi.model.GoneException;
+import software.amazon.awssdk.services.apigatewaymanagementapi.model.PostToConnectionRequest;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * WebSocket 연결들에게 메시지를 브로드캐스트하는 유틸리티
+ */
+public class WebSocketBroadcaster {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketBroadcaster.class);
+
+    private final ApiGatewayManagementApiClient apiClient;
+
+    public WebSocketBroadcaster() {
+        String endpoint = WebSocketConfig.websocketEndpoint();
+        this.apiClient = ApiGatewayManagementApiClient.builder()
+                .endpointOverride(URI.create(endpoint))
+                .build();
+    }
+
+    public WebSocketBroadcaster(String endpoint) {
+        this.apiClient = ApiGatewayManagementApiClient.builder()
+                .endpointOverride(URI.create(endpoint))
+                .build();
+    }
+
+    /**
+     * 단일 연결에 메시지 전송
+     * @return 전송 성공 여부
+     */
+    public boolean sendToConnection(String connectionId, String message) {
+        try {
+            PostToConnectionRequest request = PostToConnectionRequest.builder()
+                    .connectionId(connectionId)
+                    .data(SdkBytes.fromString(message, StandardCharsets.UTF_8))
+                    .build();
+
+            apiClient.postToConnection(request);
+            logger.debug("Message sent to connection: {}", connectionId);
+            return true;
+
+        } catch (GoneException e) {
+            logger.warn("Connection gone: {}", connectionId);
+            return false;
+
+        } catch (Exception e) {
+            logger.error("Failed to send message to connection {}: {}", connectionId, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 여러 연결에 메시지 브로드캐스트
+     * @return 전송 실패한 connectionId 목록
+     */
+    public List<String> broadcast(List<Connection> connections, String message) {
+        List<String> failedConnections = new ArrayList<>();
+
+        for (Connection connection : connections) {
+            boolean success = sendToConnection(connection.getConnectionId(), message);
+            if (!success) {
+                failedConnections.add(connection.getConnectionId());
+            }
+        }
+
+        logger.info("Broadcast completed: total={}, failed={}",
+                connections.size(), failedConnections.size());
+
+        return failedConnections;
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketMessageHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketMessageHandler.java
@@ -1,0 +1,126 @@
+package com.mzc.secondproject.serverless.domain.chatting.handler.websocket;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.mzc.secondproject.serverless.common.util.WebSocketBroadcaster;
+import com.mzc.secondproject.serverless.domain.chatting.model.ChatMessage;
+import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ChatRoomRepository;
+import com.mzc.secondproject.serverless.domain.chatting.service.ChatMessageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * WebSocket sendMessage 라우트 핸들러
+ * 메시지 저장 및 같은 방 연결들에게 브로드캐스트
+ */
+public class WebSocketMessageHandler implements RequestHandler<Map<String, Object>, Map<String, Object>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketMessageHandler.class);
+    private static final Gson gson = new GsonBuilder().create();
+
+    private final ChatMessageService chatMessageService;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ConnectionRepository connectionRepository;
+    private final WebSocketBroadcaster broadcaster;
+
+    public WebSocketMessageHandler() {
+        this.chatMessageService = new ChatMessageService();
+        this.chatRoomRepository = new ChatRoomRepository();
+        this.connectionRepository = new ConnectionRepository();
+        this.broadcaster = new WebSocketBroadcaster();
+    }
+
+    @Override
+    public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
+        logger.info("WebSocket message event: {}", event);
+
+        try {
+            String connectionId = extractConnectionId(event);
+            String body = (String) event.get("body");
+
+            if (body == null || body.isEmpty()) {
+                return createResponse(400, "Message body is required");
+            }
+
+            MessagePayload payload = gson.fromJson(body, MessagePayload.class);
+
+            if (payload.roomId == null || payload.userId == null || payload.content == null) {
+                return createResponse(400, "roomId, userId, and content are required");
+            }
+
+            String messageType = payload.messageType != null ? payload.messageType : "TEXT";
+            String messageId = UUID.randomUUID().toString();
+            String now = Instant.now().toString();
+
+            ChatMessage message = ChatMessage.builder()
+                    .pk("ROOM#" + payload.roomId)
+                    .sk("MSG#" + now + "#" + messageId)
+                    .gsi1pk("USER#" + payload.userId)
+                    .gsi1sk("MSG#" + now)
+                    .gsi2pk("MSG#" + messageId)
+                    .gsi2sk("ROOM#" + payload.roomId)
+                    .messageId(messageId)
+                    .roomId(payload.roomId)
+                    .userId(payload.userId)
+                    .content(payload.content)
+                    .messageType(messageType)
+                    .createdAt(now)
+                    .build();
+
+            ChatMessage savedMessage = chatMessageService.saveMessage(message);
+            chatRoomRepository.updateLastMessageAt(payload.roomId, now);
+
+            logger.info("Message saved: messageId={}, roomId={}", messageId, payload.roomId);
+
+            // 브로드캐스트
+            List<Connection> connections = connectionRepository.findByRoomId(payload.roomId);
+            String broadcastPayload = gson.toJson(savedMessage);
+            List<String> failedConnections = broadcaster.broadcast(connections, broadcastPayload);
+
+            // 실패한 연결 정리
+            for (String failedConnectionId : failedConnections) {
+                connectionRepository.delete(failedConnectionId);
+                logger.info("Deleted stale connection: {}", failedConnectionId);
+            }
+
+            return createResponse(200, "Message sent");
+
+        } catch (Exception e) {
+            logger.error("Error handling message: {}", e.getMessage(), e);
+            return createResponse(500, "Internal server error");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String extractConnectionId(Map<String, Object> event) {
+        Map<String, Object> requestContext = (Map<String, Object>) event.get("requestContext");
+        return (String) requestContext.get("connectionId");
+    }
+
+    private Map<String, Object> createResponse(int statusCode, String body) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("statusCode", statusCode);
+        response.put("body", body);
+        return response;
+    }
+
+    /**
+     * 메시지 페이로드 DTO
+     */
+    private static class MessagePayload {
+        String roomId;
+        String userId;
+        String content;
+        String messageType;
+    }
+}


### PR DESCRIPTION
## Summary
- WebSocket을 통한 실시간 메시지 전송 및 브로드캐스트 구현

## Changes
- apigatewaymanagementapi 의존성 추가
- WebSocketBroadcaster: 연결들에게 메시지 푸시 유틸리티
- WebSocketMessageHandler: 메시지 저장 및 브로드캐스트
- 실패한 연결(GoneException) 자동 정리

## Related Issues
- refs #143 (Epic)
- refs #145 (Story)
- closes #151 (Task)

## Test plan
- [ ] 메시지 전송 시 DynamoDB에 저장되는지 확인
- [ ] 같은 방의 모든 연결에 메시지가 브로드캐스트되는지 확인
- [ ] 연결 끊긴 클라이언트가 자동 정리되는지 확인