### PR TITLE
feat: Vocabulary API Cognito 인증 적용

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/router/AuthenticatedHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/router/AuthenticatedHandler.java
@@ -1,0 +1,14 @@
+package com.mzc.secondproject.serverless.common.router;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+
+/**
+ * Cognito 인증이 필요한 요청 핸들러
+ *
+ * userId가 자동으로 추출되어 전달됩니다.
+ */
+@FunctionalInterface
+public interface AuthenticatedHandler {
+    APIGatewayProxyResponseEvent handle(APIGatewayProxyRequestEvent request, String userId);
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/router/Route.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/router/Route.java
@@ -2,6 +2,7 @@ package com.mzc.secondproject.serverless.common.router;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.mzc.secondproject.serverless.common.util.CognitoUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +62,54 @@ public record Route(
 
     public static Route patch(String pathPattern, Function<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler) {
         return new Route("PATCH", pathPattern, handler, extractPathParams(pathPattern), List.of());
+    }
+
+    // ============ Cognito 인증 핸들러 메서드 ============
+
+    /**
+     * Cognito 인증이 필요한 GET 라우트
+     * userId가 자동으로 추출되어 핸들러에 전달됩니다.
+     */
+    public static Route getAuth(String pathPattern, AuthenticatedHandler handler) {
+        return new Route("GET", pathPattern,
+                request -> handler.handle(request, CognitoUtil.extractUserId(request)),
+                extractPathParams(pathPattern), List.of());
+    }
+
+    /**
+     * Cognito 인증이 필요한 POST 라우트
+     */
+    public static Route postAuth(String pathPattern, AuthenticatedHandler handler) {
+        return new Route("POST", pathPattern,
+                request -> handler.handle(request, CognitoUtil.extractUserId(request)),
+                extractPathParams(pathPattern), List.of());
+    }
+
+    /**
+     * Cognito 인증이 필요한 PUT 라우트
+     */
+    public static Route putAuth(String pathPattern, AuthenticatedHandler handler) {
+        return new Route("PUT", pathPattern,
+                request -> handler.handle(request, CognitoUtil.extractUserId(request)),
+                extractPathParams(pathPattern), List.of());
+    }
+
+    /**
+     * Cognito 인증이 필요한 DELETE 라우트
+     */
+    public static Route deleteAuth(String pathPattern, AuthenticatedHandler handler) {
+        return new Route("DELETE", pathPattern,
+                request -> handler.handle(request, CognitoUtil.extractUserId(request)),
+                extractPathParams(pathPattern), List.of());
+    }
+
+    /**
+     * Cognito 인증이 필요한 PATCH 라우트
+     */
+    public static Route patchAuth(String pathPattern, AuthenticatedHandler handler) {
+        return new Route("PATCH", pathPattern,
+                request -> handler.handle(request, CognitoUtil.extractUserId(request)),
+                extractPathParams(pathPattern), List.of());
     }
 
     /**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/CognitoUtil.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/CognitoUtil.java
@@ -1,0 +1,131 @@
+package com.mzc.secondproject.serverless.common.util;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.mzc.secondproject.serverless.common.exception.CommonErrorCode;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Cognito Authorizer에서 사용자 정보를 추출하는 유틸리티 클래스
+ */
+public class CognitoUtil {
+
+    private CognitoUtil() {
+        // 유틸리티 클래스 인스턴스화 방지
+    }
+
+    /**
+     * Cognito claims에서 userId(sub)를 추출
+     *
+     * @param request API Gateway 요청
+     * @return userId (Cognito sub)
+     * @throws IllegalStateException claims가 없거나 sub가 없는 경우
+     */
+    public static String extractUserId(APIGatewayProxyRequestEvent request) {
+        return extractClaim(request, "sub")
+                .orElseThrow(() -> new IllegalStateException("Cognito sub claim not found"));
+    }
+
+    /**
+     * Cognito claims에서 email을 추출
+     *
+     * @param request API Gateway 요청
+     * @return email (Optional)
+     */
+    public static Optional<String> extractEmail(APIGatewayProxyRequestEvent request) {
+        return extractClaim(request, "email");
+    }
+
+    /**
+     * Cognito claims에서 nickname을 추출
+     *
+     * @param request API Gateway 요청
+     * @return nickname (Optional)
+     */
+    public static Optional<String> extractNickname(APIGatewayProxyRequestEvent request) {
+        return extractClaim(request, "custom:nickname");
+    }
+
+    /**
+     * Cognito claims에서 특정 claim을 추출
+     *
+     * @param request API Gateway 요청
+     * @param claimName claim 이름
+     * @return claim 값 (Optional)
+     */
+    @SuppressWarnings("unchecked")
+    public static Optional<String> extractClaim(APIGatewayProxyRequestEvent request, String claimName) {
+        try {
+            Map<String, Object> authorizer = request.getRequestContext().getAuthorizer();
+            if (authorizer == null) {
+                return Optional.empty();
+            }
+
+            Map<String, String> claims = (Map<String, String>) authorizer.get("claims");
+            if (claims == null) {
+                return Optional.empty();
+            }
+
+            return Optional.ofNullable(claims.get(claimName));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 경로 파라미터의 userId와 Cognito userId가 일치하는지 검증
+     *
+     * @param request API Gateway 요청
+     * @param pathUserId 경로 파라미터에서 추출한 userId
+     * @return 일치 여부
+     */
+    public static boolean validateUserAccess(APIGatewayProxyRequestEvent request, String pathUserId) {
+        try {
+            String cognitoUserId = extractUserId(request);
+            return cognitoUserId.equals(pathUserId);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * 경로 파라미터와 Cognito userId를 검증하고, 유효한 경우 userId 반환
+     * 검증 실패 시 Optional.empty() 반환
+     *
+     * @param request API Gateway 요청
+     * @param pathUserId 경로 파라미터에서 추출한 userId
+     * @return 검증된 userId (Optional)
+     */
+    public static Optional<String> validateAndExtractUserId(APIGatewayProxyRequestEvent request, String pathUserId) {
+        try {
+            String cognitoUserId = extractUserId(request);
+            if (cognitoUserId.equals(pathUserId)) {
+                return Optional.of(cognitoUserId);
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 경로 파라미터에서 userId를 추출하고 Cognito 토큰과 검증
+     * Handler에서 간편하게 사용할 수 있는 메서드
+     *
+     * @param request API Gateway 요청
+     * @return 검증된 userId (Optional)
+     */
+    public static Optional<String> getValidatedUserId(APIGatewayProxyRequestEvent request) {
+        String pathUserId = request.getPathParameters() != null
+                ? request.getPathParameters().get("userId")
+                : null;
+
+        if (pathUserId == null) {
+            // 경로에 userId가 없으면 토큰에서만 추출
+            return extractClaim(request, "sub");
+        }
+
+        return validateAndExtractUserId(request, pathUserId);
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/DailyStudyHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/DailyStudyHandler.java
@@ -32,8 +32,8 @@ public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestE
 
     private HandlerRouter initRouter() {
         return new HandlerRouter().addRoutes(
-                Route.post("/daily/{userId}/words/{wordId}/learned", this::markWordLearned),
-                Route.get("/daily/{userId}", this::getDailyWords)
+                Route.postAuth("/daily/words/{wordId}/learned", this::markWordLearned),
+                Route.getAuth("/daily", this::getDailyWords)
         );
     }
 
@@ -43,8 +43,7 @@ public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestE
         return router.route(request);
     }
 
-    private APIGatewayProxyResponseEvent getDailyWords(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent getDailyWords(APIGatewayProxyRequestEvent request, String userId) {
         Map<String, String> queryParams = request.getQueryStringParameters();
 
         String date = queryParams != null ? queryParams.get("date") : null;
@@ -71,7 +70,7 @@ public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestE
         var optDailyStudy = queryService.getDailyStudy(userId, date);
 
         if (optDailyStudy.isEmpty()) {
-            return ResponseGenerator.fail(VocabularyErrorCode.DAILY_STUDY_NOT_FOUND, "No daily study found for date: " + date);
+            return ResponseGenerator.fail(VocabularyErrorCode.DAILY_STUDY_NOT_FOUND);
         }
 
         var dailyStudy = optDailyStudy.get();
@@ -88,8 +87,7 @@ public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestE
         return ResponseGenerator.ok("Daily study retrieved for " + date, response);
     }
 
-    private APIGatewayProxyResponseEvent markWordLearned(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent markWordLearned(APIGatewayProxyRequestEvent request, String userId) {
         String wordId = request.getPathParameters().get("wordId");
 
         Map<String, Object> progress = commandService.markWordLearned(userId, wordId);

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatsHandler.java
@@ -28,9 +28,9 @@ public class StatsHandler implements RequestHandler<APIGatewayProxyRequestEvent,
 
     private HandlerRouter initRouter() {
         return new HandlerRouter().addRoutes(
-                Route.get("/stats/{userId}/weakness", this::getWeaknessAnalysis),
-                Route.get("/stats/{userId}/daily", this::getDailyStats),
-                Route.get("/stats/{userId}", this::getOverallStats)
+                Route.getAuth("/stats/weakness", this::getWeaknessAnalysis),
+                Route.getAuth("/stats/daily", this::getDailyStats),
+                Route.getAuth("/stats", this::getOverallStats)
         );
     }
 
@@ -40,15 +40,12 @@ public class StatsHandler implements RequestHandler<APIGatewayProxyRequestEvent,
         return router.route(request);
     }
 
-    private APIGatewayProxyResponseEvent getOverallStats(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
-
+    private APIGatewayProxyResponseEvent getOverallStats(APIGatewayProxyRequestEvent request, String userId) {
         Map<String, Object> stats = statsService.getOverallStats(userId);
         return ResponseGenerator.ok("Stats retrieved", stats);
     }
 
-    private APIGatewayProxyResponseEvent getDailyStats(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent getDailyStats(APIGatewayProxyRequestEvent request, String userId) {
         Map<String, String> queryParams = request.getQueryStringParameters();
         String cursor = queryParams != null ? queryParams.get("cursor") : null;
 
@@ -67,9 +64,7 @@ public class StatsHandler implements RequestHandler<APIGatewayProxyRequestEvent,
         return ResponseGenerator.ok("Daily stats retrieved", result);
     }
 
-    private APIGatewayProxyResponseEvent getWeaknessAnalysis(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
-
+    private APIGatewayProxyResponseEvent getWeaknessAnalysis(APIGatewayProxyRequestEvent request, String userId) {
         Map<String, Object> analysis = statsService.getWeaknessAnalysis(userId);
         return ResponseGenerator.ok("Weakness analysis completed", analysis);
     }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/UserWordHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/UserWordHandler.java
@@ -38,11 +38,11 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
 
     private HandlerRouter initRouter() {
         return new HandlerRouter().addRoutes(
-                Route.get("/users/{userId}/wrong-answers", this::getWrongAnswers),
-                Route.get("/users/{userId}/words", this::getUserWords),
-                Route.get("/users/{userId}/words/{wordId}", this::getUserWord),
-                Route.put("/users/{userId}/words/{wordId}/tag", this::updateUserWordTag),
-                Route.put("/users/{userId}/words/{wordId}", this::updateUserWord)
+                Route.getAuth("/wrong-answers", this::getWrongAnswers),
+                Route.getAuth("/words", this::getUserWords),
+                Route.getAuth("/words/{wordId}", this::getUserWord),
+                Route.putAuth("/words/{wordId}/tag", this::updateUserWordTag),
+                Route.putAuth("/words/{wordId}", this::updateUserWord)
         );
     }
 
@@ -52,8 +52,7 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         return router.route(request);
     }
 
-    private APIGatewayProxyResponseEvent getUserWords(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent getUserWords(APIGatewayProxyRequestEvent request, String userId) {
         Map<String, String> queryParams = request.getQueryStringParameters();
 
         String status = queryParams != null ? queryParams.get("status") : null;
@@ -76,8 +75,7 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         return ResponseGenerator.ok("User words retrieved", response);
     }
 
-    private APIGatewayProxyResponseEvent getUserWord(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent getUserWord(APIGatewayProxyRequestEvent request, String userId) {
         String wordId = request.getPathParameters().get("wordId");
 
         Optional<UserWord> optUserWord = queryService.getUserWord(userId, wordId);
@@ -88,8 +86,7 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         return ResponseGenerator.ok("UserWord retrieved", optUserWord.get());
     }
 
-    private APIGatewayProxyResponseEvent updateUserWord(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent updateUserWord(APIGatewayProxyRequestEvent request, String userId) {
         String wordId = request.getPathParameters().get("wordId");
         UpdateUserWordRequest req = ResponseGenerator.gson().fromJson(request.getBody(), UpdateUserWordRequest.class);
 
@@ -99,8 +96,7 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         });
     }
 
-    private APIGatewayProxyResponseEvent updateUserWordTag(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent updateUserWordTag(APIGatewayProxyRequestEvent request, String userId) {
         String wordId = request.getPathParameters().get("wordId");
         UpdateUserWordTagRequest req = ResponseGenerator.gson().fromJson(request.getBody(), UpdateUserWordTagRequest.class);
 
@@ -108,8 +104,7 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
         return ResponseGenerator.ok("Tag updated", userWord);
     }
 
-    private APIGatewayProxyResponseEvent getWrongAnswers(APIGatewayProxyRequestEvent request) {
-        String userId = request.getPathParameters().get("userId");
+    private APIGatewayProxyResponseEvent getWrongAnswers(APIGatewayProxyRequestEvent request, String userId) {
         Map<String, String> queryParams = request.getQueryStringParameters();
         String cursor = queryParams != null ? queryParams.get("cursor") : null;
 

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -541,42 +541,42 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/wrong-answers
+            Path: /vocab/wrong-answers
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetUserWords:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/words
+            Path: /vocab/words
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetUserWord:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/words/{wordId}
+            Path: /vocab/words/{wordId}
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         UpdateUserWord:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/words/{wordId}
+            Path: /vocab/words/{wordId}
             Method: PUT
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         UpdateUserWordTag:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/words/{wordId}/tag
+            Path: /vocab/words/{wordId}/tag
             Method: PUT
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
 
   WordGroupFunction:
     Type: AWS::Serverless::Function
@@ -595,58 +595,58 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/groups
+            Path: /vocab/groups
             Method: POST
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetGroups:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/groups
+            Path: /vocab/groups
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetGroupDetail:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/groups/{groupId}
+            Path: /vocab/groups/{groupId}
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         UpdateGroup:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/groups/{groupId}
+            Path: /vocab/groups/{groupId}
             Method: PUT
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         DeleteGroup:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/groups/{groupId}
+            Path: /vocab/groups/{groupId}
             Method: DELETE
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         AddWordToGroup:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/groups/{groupId}/words/{wordId}
+            Path: /vocab/groups/{groupId}/words/{wordId}
             Method: POST
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         RemoveWordFromGroup:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/users/{userId}/groups/{groupId}/words/{wordId}
+            Path: /vocab/groups/{groupId}/words/{wordId}
             Method: DELETE
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
 
   DailyStudyFunction:
     Type: AWS::Serverless::Function
@@ -665,18 +665,18 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/daily/{userId}
+            Path: /vocab/daily
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         MarkWordLearned:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/daily/{userId}/words/{wordId}/learned
+            Path: /vocab/daily/words/{wordId}/learned
             Method: POST
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
 
   TestFunction:
     Type: AWS::Serverless::Function
@@ -700,34 +700,34 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/test/{userId}/start
+            Path: /vocab/test/start
             Method: POST
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         SubmitAnswer:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/test/{userId}/submit
+            Path: /vocab/test/submit
             Method: POST
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetTestResults:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/test/{userId}/results
+            Path: /vocab/test/results
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetTestResultDetail:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/test/{userId}/results/{testId}
+            Path: /vocab/test/results/{testId}
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
 
   StatsFunction:
     Type: AWS::Serverless::Function
@@ -746,26 +746,26 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/stats/{userId}
+            Path: /vocab/stats
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetDailyStats:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/stats/{userId}/daily
+            Path: /vocab/stats/daily
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
         GetWeaknessAnalysis:
           Type: Api
           Properties:
             RestApiId: !Ref MainApi
-            Path: /vocab/stats/{userId}/weakness
+            Path: /vocab/stats/weakness
             Method: GET
-            # Auth:
-            #   Authorizer: CognitoAuthorizer
+            Auth:
+              Authorizer: CognitoAuthorizer
 
   VocabVoiceFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## Summary
- Vocabulary API에 Cognito Authorizer 적용
- CognitoUtil 유틸리티 클래스 추가로 토큰에서 userId 추출
- API 엔드포인트 경로에서 userId 제거 (토큰에서 추출)
- AuthenticatedHandler 인터페이스로 중복 코드 제거

## Changes
### Task #188: Cognito Authorizer 설정
- template.yaml에서 Vocabulary API에 CognitoAuthorizer 활성화

### Task #189: 토큰 추출 로직 구현
- CognitoUtil 클래스 추가 (extractUserId, extractEmail, extractNickname 등)

### Task #190: API 엔드포인트 경로 변경
- `/vocab/users/{userId}/words` → `/vocab/words`
- `/vocab/users/{userId}/groups` → `/vocab/groups`
- `/vocab/daily/{userId}` → `/vocab/daily`
- `/vocab/test/{userId}/start` → `/vocab/test/start`
- `/vocab/stats/{userId}` → `/vocab/stats`
- AuthenticatedHandler 인터페이스 및 Route.getAuth/postAuth/putAuth/deleteAuth 메서드 추가

## Test plan
- [ ] Cognito 토큰 없이 API 호출 시 401 응답 확인
- [ ] 유효한 토큰으로 API 호출 시 정상 동작 확인
- [ ] 토큰에서 userId가 정상적으로 추출되는지 확인

Closes #185