### PR TITLE
hotfix: Chat Request DTO userId validation 제거

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/CreateRoomRequest.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/CreateRoomRequest.java
@@ -34,7 +34,4 @@ public class CreateRoomRequest {
     private Boolean isPrivate = false;
 
     private String password;
-
-    @NotBlank(message = "is required")
-    private String createdBy;
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/JoinRoomRequest.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/JoinRoomRequest.java
@@ -1,6 +1,5 @@
 package com.mzc.secondproject.serverless.domain.chatting.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,9 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class JoinRoomRequest {
-
-    @NotBlank(message = "is required")
-    private String userId;
 
     private String password;
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/LeaveRoomRequest.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/LeaveRoomRequest.java
@@ -1,6 +1,5 @@
 package com.mzc.secondproject.serverless.domain.chatting.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,9 +8,6 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
 public class LeaveRoomRequest {
-
-    @NotBlank(message = "is required")
-    private String userId;
+    // 토큰에서 userId를 추출하므로 별도 필드 불필요
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/SendMessageRequest.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/SendMessageRequest.java
@@ -14,9 +14,6 @@ import lombok.NoArgsConstructor;
 public class SendMessageRequest {
 
     @NotBlank(message = "is required")
-    private String userId;
-
-    @NotBlank(message = "is required")
     @Size(max = 1000, message = "must be at most 1000 characters")
     private String content;
 


### PR DESCRIPTION
## Summary
- Cognito 토큰에서 userId를 추출하므로 Request DTO의 userId validation 제거

## Changes
- CreateRoomRequest: createdBy 필드 및 @NotBlank 제거
- JoinRoomRequest: userId 필드 및 @NotBlank 제거
- LeaveRoomRequest: userId 필드 및 @NotBlank 제거
- SendMessageRequest: userId 필드 및 @NotBlank 제거

## Test plan
- [ ] Chat 방 생성 API 테스트
- [ ] Chat 방 참여 API 테스트
- [ ] Chat 방 퇴장 API 테스트
- [ ] 메시지 전송 API 테스트

Closes #196