### PR TITLE
improve: 도메인 예외 처리 구체화 (#199)

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
@@ -14,6 +14,8 @@ public enum ChattingErrorCode implements DomainErrorCode {
     ROOM_ALREADY_EXISTS("ROOM_002", "이미 존재하는 채팅방입니다", 409),
     ROOM_FULL("ROOM_003", "채팅방 인원이 가득 찼습니다", 400),
     ROOM_CLOSED("ROOM_004", "종료된 채팅방입니다", 400),
+    ROOM_INVALID_PASSWORD("ROOM_005", "비밀번호가 일치하지 않습니다", 401),
+    ROOM_NOT_OWNER("ROOM_006", "방장 권한이 필요합니다", 403),
 
     // 메시지 관련 에러
     MESSAGE_NOT_FOUND("MSG_001", "메시지를 찾을 수 없습니다", 404),

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingException.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingException.java
@@ -52,6 +52,19 @@ public class ChattingException extends ServerlessException {
                 .addDetail("roomId", roomId);
     }
 
+    public static ChattingException roomInvalidPassword(String roomId) {
+        return (ChattingException) new ChattingException(ChattingErrorCode.ROOM_INVALID_PASSWORD,
+                "비밀번호가 일치하지 않습니다")
+                .addDetail("roomId", roomId);
+    }
+
+    public static ChattingException roomNotOwner(String userId, String roomId) {
+        return (ChattingException) new ChattingException(ChattingErrorCode.ROOM_NOT_OWNER,
+                String.format("방장 권한이 필요합니다 (userId: %s, roomId: %s)", userId, roomId))
+                .addDetail("userId", userId)
+                .addDetail("roomId", roomId);
+    }
+
     // === 메시지(Message) 관련 팩토리 메서드 ===
 
     public static ChattingException messageNotFound(String messageId) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyErrorCode.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyErrorCode.java
@@ -27,6 +27,14 @@ public enum VocabularyErrorCode implements DomainErrorCode {
     // 카테고리/레벨 관련 에러
     INVALID_CATEGORY("CATEGORY_001", "유효하지 않은 카테고리입니다", 400),
     INVALID_LEVEL("LEVEL_001", "유효하지 않은 레벨입니다", 400),
+
+    // 단어 그룹 관련 에러
+    GROUP_NOT_FOUND("GROUP_001", "단어 그룹을 찾을 수 없습니다", 404),
+    GROUP_ALREADY_EXISTS("GROUP_002", "이미 존재하는 그룹입니다", 409),
+
+    // 테스트 관련 에러
+    TEST_NOT_FOUND("TEST_001", "테스트 정보를 찾을 수 없습니다", 404),
+    NO_WORDS_TO_TEST("TEST_002", "테스트할 단어가 없습니다", 400),
     ;
 
     private static final String DOMAIN = "VOCABULARY";

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyException.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyException.java
@@ -99,4 +99,25 @@ public class VocabularyException extends ServerlessException {
                 String.format("유효하지 않은 레벨입니다: '%s'", level))
                 .addDetail("invalidValue", level);
     }
+
+    // === 단어 그룹(WordGroup) 관련 팩토리 메서드 ===
+
+    public static VocabularyException groupNotFound(String groupId) {
+        return (VocabularyException) new VocabularyException(VocabularyErrorCode.GROUP_NOT_FOUND,
+                String.format("단어 그룹을 찾을 수 없습니다 (ID: %s)", groupId))
+                .addDetail("groupId", groupId);
+    }
+
+    public static VocabularyException groupAlreadyExists(String groupName) {
+        return (VocabularyException) new VocabularyException(VocabularyErrorCode.GROUP_ALREADY_EXISTS,
+                String.format("이미 존재하는 그룹입니다: '%s'", groupName))
+                .addDetail("groupName", groupName);
+    }
+
+    // === 테스트(Test) 관련 팩토리 메서드 ===
+
+    public static VocabularyException noWordsToTest() {
+        return new VocabularyException(VocabularyErrorCode.NO_WORDS_TO_TEST,
+                "테스트할 단어가 없습니다. 먼저 일일 학습을 시작해주세요.");
+    }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
@@ -12,6 +12,8 @@ import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordReposit
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.mzc.secondproject.serverless.domain.vocabulary.exception.VocabularyException;
+
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -54,10 +56,10 @@ public class DailyStudyCommandService {
             dailyStudy = optDailyStudy.get();
         } else {
             if (level == null || level.isEmpty()) {
-                throw new IllegalArgumentException("level is required for first daily study (BEGINNER, INTERMEDIATE, ADVANCED)");
+                throw VocabularyException.invalidStudyLevel("level is required (BEGINNER, INTERMEDIATE, ADVANCED)");
             }
             if (!StudyLevel.isValid(level)) {
-                throw new IllegalArgumentException("Invalid level. Must be BEGINNER, INTERMEDIATE, or ADVANCED");
+                throw VocabularyException.invalidStudyLevel(level);
             }
             dailyStudy = createDailyStudy(userId, today, level);
         }
@@ -74,7 +76,7 @@ public class DailyStudyCommandService {
 
         Optional<DailyStudy> optDailyStudy = dailyStudyRepository.findByUserIdAndDate(userId, today);
         if (optDailyStudy.isEmpty()) {
-            throw new IllegalStateException("Daily study not found");
+            throw VocabularyException.dailyStudyNotFound(userId, today);
         }
 
         DailyStudy dailyStudy = optDailyStudy.get();

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
+import com.mzc.secondproject.serverless.domain.vocabulary.exception.VocabularyException;
 import com.mzc.secondproject.serverless.domain.vocabulary.dto.request.SubmitTestRequest;
 import com.mzc.secondproject.serverless.common.config.AwsClients;
 import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
@@ -51,7 +52,7 @@ public class TestCommandService {
 
         Optional<DailyStudy> optDailyStudy = dailyStudyRepository.findByUserIdAndDate(userId, today);
         if (optDailyStudy.isEmpty()) {
-            throw new IllegalStateException("No daily study found for today");
+            throw VocabularyException.dailyStudyNotFound(userId, today);
         }
 
         DailyStudy dailyStudy = optDailyStudy.get();
@@ -60,7 +61,7 @@ public class TestCommandService {
         if (dailyStudy.getReviewWordIds() != null) allWordIds.addAll(dailyStudy.getReviewWordIds());
 
         if (allWordIds.isEmpty()) {
-            throw new IllegalStateException("No words to test");
+            throw VocabularyException.noWordsToTest();
         }
 
         List<Word> words = wordRepository.findByIds(allWordIds);

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordGroupCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordGroupCommandService.java
@@ -1,5 +1,6 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
+import com.mzc.secondproject.serverless.domain.vocabulary.exception.VocabularyException;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.WordGroup;
 import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordGroupRepository;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ public class WordGroupCommandService {
     public WordGroup updateGroup(String userId, String groupId, String groupName, String description) {
         Optional<WordGroup> optGroup = wordGroupRepository.findByUserIdAndGroupId(userId, groupId);
         if (optGroup.isEmpty()) {
-            throw new IllegalArgumentException("Word group not found");
+            throw VocabularyException.groupNotFound(groupId);
         }
 
         WordGroup group = optGroup.get();
@@ -71,7 +72,7 @@ public class WordGroupCommandService {
     public void deleteGroup(String userId, String groupId) {
         Optional<WordGroup> optGroup = wordGroupRepository.findByUserIdAndGroupId(userId, groupId);
         if (optGroup.isEmpty()) {
-            throw new IllegalArgumentException("Word group not found");
+            throw VocabularyException.groupNotFound(groupId);
         }
 
         wordGroupRepository.delete(userId, groupId);
@@ -81,7 +82,7 @@ public class WordGroupCommandService {
     public WordGroup addWordToGroup(String userId, String groupId, String wordId) {
         Optional<WordGroup> optGroup = wordGroupRepository.findByUserIdAndGroupId(userId, groupId);
         if (optGroup.isEmpty()) {
-            throw new IllegalArgumentException("Word group not found");
+            throw VocabularyException.groupNotFound(groupId);
         }
 
         WordGroup group = optGroup.get();
@@ -105,7 +106,7 @@ public class WordGroupCommandService {
     public WordGroup removeWordFromGroup(String userId, String groupId, String wordId) {
         Optional<WordGroup> optGroup = wordGroupRepository.findByUserIdAndGroupId(userId, groupId);
         if (optGroup.isEmpty()) {
-            throw new IllegalArgumentException("Word group not found");
+            throw VocabularyException.groupNotFound(groupId);
         }
 
         WordGroup group = optGroup.get();


### PR DESCRIPTION
## Summary
- VocabularyErrorCode 및 ChattingErrorCode에 누락된 에러 코드 추가
- VocabularyException 및 ChattingException에 팩토리 메서드 추가
- 서비스 레이어에서 IllegalArgumentException/IllegalStateException/SecurityException을 도메인 예외로 교체

## Changes
### Vocabulary 도메인
- `GROUP_NOT_FOUND`, `GROUP_ALREADY_EXISTS`, `TEST_NOT_FOUND`, `NO_WORDS_TO_TEST` 에러 코드 추가
- `groupNotFound()`, `groupAlreadyExists()`, `noWordsToTest()` 팩토리 메서드 추가
- DailyStudyCommandService, TestCommandService, WordGroupCommandService 예외 처리 개선

### Chatting 도메인
- `ROOM_INVALID_PASSWORD`, `ROOM_NOT_OWNER` 에러 코드 추가
- `roomInvalidPassword()`, `roomNotOwner()` 팩토리 메서드 추가
- ChatRoomService, ChatRoomCommandService 예외 처리 개선

## Test plan
- [ ] 존재하지 않는 채팅방 접근 시 적절한 에러 메시지 반환 확인
- [ ] 잘못된 비밀번호로 비공개 방 입장 시 에러 메시지 확인
- [ ] 일일 학습 없이 테스트 시작 시 에러 메시지 확인

closes #199
