### PR TITLE
[TASK] #209 UserStats 모델 및 Repository 구현

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/constants/StatsKey.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/constants/StatsKey.java
@@ -1,0 +1,41 @@
+package com.mzc.secondproject.serverless.domain.stats.constants;
+
+import com.mzc.secondproject.serverless.common.constants.DynamoDbKey;
+
+/**
+ * 학습 통계 도메인 키 상수
+ */
+public final class StatsKey {
+
+    private StatsKey() {}
+
+    // Suffix
+    public static final String SUFFIX_STATS = "#STATS";
+
+    // Stats Period Prefixes
+    public static final String STATS_DAILY = "DAILY#";
+    public static final String STATS_WEEKLY = "WEEKLY#";
+    public static final String STATS_MONTHLY = "MONTHLY#";
+    public static final String STATS_TOTAL = "TOTAL";
+
+    // Key Builders
+    public static String userStatsPk(String userId) {
+        return DynamoDbKey.USER + userId + SUFFIX_STATS;
+    }
+
+    public static String statsDailySk(String date) {
+        return STATS_DAILY + date;
+    }
+
+    public static String statsWeeklySk(String yearWeek) {
+        return STATS_WEEKLY + yearWeek;
+    }
+
+    public static String statsMonthlySk(String yearMonth) {
+        return STATS_MONTHLY + yearMonth;
+    }
+
+    public static String statsTotalSk() {
+        return STATS_TOTAL;
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/model/UserStats.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/model/UserStats.java
@@ -1,0 +1,67 @@
+package com.mzc.secondproject.serverless.domain.stats.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+/**
+ * 사용자 학습 통계
+ * PK: USER#{userId}#STATS
+ * SK: DAILY#{date} / WEEKLY#{year}-W{week} / MONTHLY#{year}-{month} / TOTAL
+ *
+ * Write-time Aggregation 패턴:
+ * - 이벤트 발생 시 Atomic Counter로 증분 업데이트
+ * - 조회 시 Scan 없이 O(1) GetItem
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamoDbBean
+public class UserStats {
+
+    private String pk;          // USER#{userId}#STATS
+    private String sk;          // DAILY#{date} / WEEKLY#{year}-W{week} / MONTHLY#{year}-{month} / TOTAL
+
+    private String userId;
+    private String periodType;  // DAILY, WEEKLY, MONTHLY, TOTAL
+    private String period;      // 2026-01-13, 2026-W02, 2026-01, TOTAL
+
+    // 테스트 통계
+    private Integer testsCompleted;     // 완료한 테스트 수
+    private Integer questionsAnswered;  // 답변한 문제 수
+    private Integer correctAnswers;     // 정답 수
+    private Integer incorrectAnswers;   // 오답 수
+    private Double successRate;         // 정답률
+
+    // 학습 통계
+    private Integer newWordsLearned;    // 새로 학습한 단어 수
+    private Integer wordsReviewed;      // 복습한 단어 수
+    private Integer wordsMastered;      // 마스터한 단어 수
+
+    // Streak (연속 학습)
+    private Integer currentStreak;      // 현재 연속 학습일
+    private Integer longestStreak;      // 최장 연속 학습일
+    private String lastStudyDate;       // 마지막 학습일
+
+    // 메타데이터
+    private String createdAt;
+    private String updatedAt;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("PK")
+    public String getPk() {
+        return pk;
+    }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute("SK")
+    public String getSk() {
+        return sk;
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/repository/UserStatsRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/repository/UserStatsRepository.java
@@ -1,0 +1,278 @@
+package com.mzc.secondproject.serverless.domain.stats.repository;
+
+import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
+import com.mzc.secondproject.serverless.common.util.CursorUtil;
+import com.mzc.secondproject.serverless.domain.stats.constants.StatsKey;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 사용자 학습 통계 Repository
+ * Atomic Counter 패턴을 사용하여 Scan 없이 통계 업데이트
+ */
+public class UserStatsRepository {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserStatsRepository.class);
+    private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+
+    private final DynamoDbTable<UserStats> table;
+
+    public UserStatsRepository() {
+        this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(UserStats.class));
+    }
+
+    /**
+     * 특정 기간의 통계 조회
+     */
+    public Optional<UserStats> findByUserIdAndPeriod(String userId, String sk) {
+        Key key = Key.builder()
+                .partitionValue(StatsKey.userStatsPk(userId))
+                .sortValue(sk)
+                .build();
+
+        UserStats stats = table.getItem(key);
+        return Optional.ofNullable(stats);
+    }
+
+    /**
+     * 일별 통계 조회
+     */
+    public Optional<UserStats> findDailyStats(String userId, String date) {
+        return findByUserIdAndPeriod(userId, StatsKey.statsDailySk(date));
+    }
+
+    /**
+     * 주별 통계 조회
+     */
+    public Optional<UserStats> findWeeklyStats(String userId, String yearWeek) {
+        return findByUserIdAndPeriod(userId, StatsKey.statsWeeklySk(yearWeek));
+    }
+
+    /**
+     * 월별 통계 조회
+     */
+    public Optional<UserStats> findMonthlyStats(String userId, String yearMonth) {
+        return findByUserIdAndPeriod(userId, StatsKey.statsMonthlySk(yearMonth));
+    }
+
+    /**
+     * 전체 통계 조회
+     */
+    public Optional<UserStats> findTotalStats(String userId) {
+        return findByUserIdAndPeriod(userId, StatsKey.statsTotalSk());
+    }
+
+    /**
+     * 최근 N일 일별 통계 조회
+     */
+    public PaginatedResult<UserStats> findRecentDailyStats(String userId, int limit, String cursor) {
+        QueryConditional queryConditional = QueryConditional
+                .sortBeginsWith(Key.builder()
+                        .partitionValue(StatsKey.userStatsPk(userId))
+                        .sortValue(StatsKey.STATS_DAILY)
+                        .build());
+
+        QueryEnhancedRequest.Builder requestBuilder = QueryEnhancedRequest.builder()
+                .queryConditional(queryConditional)
+                .scanIndexForward(false)  // 최신순
+                .limit(limit);
+
+        if (cursor != null && !cursor.isEmpty()) {
+            Map<String, AttributeValue> exclusiveStartKey = CursorUtil.decode(cursor);
+            if (exclusiveStartKey != null) {
+                requestBuilder.exclusiveStartKey(exclusiveStartKey);
+            }
+        }
+
+        Page<UserStats> page = table.query(requestBuilder.build()).iterator().next();
+        String nextCursor = CursorUtil.encode(page.lastEvaluatedKey());
+
+        return new PaginatedResult<>(page.items(), nextCursor);
+    }
+
+    /**
+     * 테스트 결과 통계 Atomic 업데이트
+     * 일/주/월/전체 통계를 한 번에 업데이트
+     */
+    public void incrementTestStats(String userId, int correctAnswers, int incorrectAnswers) {
+        String today = LocalDate.now().toString();
+        String yearWeek = getYearWeek();
+        String yearMonth = getYearMonth();
+
+        List<String> sortKeys = List.of(
+                StatsKey.statsDailySk(today),
+                StatsKey.statsWeeklySk(yearWeek),
+                StatsKey.statsMonthlySk(yearMonth),
+                StatsKey.statsTotalSk()
+        );
+
+        String pk = StatsKey.userStatsPk(userId);
+        String now = Instant.now().toString();
+        int totalQuestions = correctAnswers + incorrectAnswers;
+
+        for (String sk : sortKeys) {
+            updateTestStats(pk, sk, correctAnswers, incorrectAnswers, totalQuestions, now);
+        }
+
+        logger.info("Incremented test stats: userId={}, correct={}, incorrect={}",
+                userId, correctAnswers, incorrectAnswers);
+    }
+
+    private void updateTestStats(String pk, String sk, int correct, int incorrect, int total, String now) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("PK", AttributeValue.builder().s(pk).build());
+        key.put("SK", AttributeValue.builder().s(sk).build());
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":correct", AttributeValue.builder().n(String.valueOf(correct)).build());
+        values.put(":incorrect", AttributeValue.builder().n(String.valueOf(incorrect)).build());
+        values.put(":total", AttributeValue.builder().n(String.valueOf(total)).build());
+        values.put(":one", AttributeValue.builder().n("1").build());
+        values.put(":zero", AttributeValue.builder().n("0").build());
+        values.put(":now", AttributeValue.builder().s(now).build());
+
+        String updateExpression = "SET " +
+                "correctAnswers = if_not_exists(correctAnswers, :zero) + :correct, " +
+                "incorrectAnswers = if_not_exists(incorrectAnswers, :zero) + :incorrect, " +
+                "questionsAnswered = if_not_exists(questionsAnswered, :zero) + :total, " +
+                "testsCompleted = if_not_exists(testsCompleted, :zero) + :one, " +
+                "updatedAt = :now, " +
+                "createdAt = if_not_exists(createdAt, :now)";
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+                .tableName(TABLE_NAME)
+                .key(key)
+                .updateExpression(updateExpression)
+                .expressionAttributeValues(values)
+                .build();
+
+        AwsClients.dynamoDb().updateItem(request);
+    }
+
+    /**
+     * 학습 완료 단어 수 Atomic 업데이트
+     */
+    public void incrementWordsLearned(String userId, int newWords, int reviewedWords) {
+        String today = LocalDate.now().toString();
+        String yearWeek = getYearWeek();
+        String yearMonth = getYearMonth();
+
+        List<String> sortKeys = List.of(
+                StatsKey.statsDailySk(today),
+                StatsKey.statsWeeklySk(yearWeek),
+                StatsKey.statsMonthlySk(yearMonth),
+                StatsKey.statsTotalSk()
+        );
+
+        String pk = StatsKey.userStatsPk(userId);
+        String now = Instant.now().toString();
+
+        for (String sk : sortKeys) {
+            updateWordsLearned(pk, sk, newWords, reviewedWords, now);
+        }
+
+        logger.info("Incremented words learned: userId={}, new={}, reviewed={}",
+                userId, newWords, reviewedWords);
+    }
+
+    private void updateWordsLearned(String pk, String sk, int newWords, int reviewedWords, String now) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("PK", AttributeValue.builder().s(pk).build());
+        key.put("SK", AttributeValue.builder().s(sk).build());
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":new", AttributeValue.builder().n(String.valueOf(newWords)).build());
+        values.put(":reviewed", AttributeValue.builder().n(String.valueOf(reviewedWords)).build());
+        values.put(":zero", AttributeValue.builder().n("0").build());
+        values.put(":now", AttributeValue.builder().s(now).build());
+
+        String updateExpression = "SET " +
+                "newWordsLearned = if_not_exists(newWordsLearned, :zero) + :new, " +
+                "wordsReviewed = if_not_exists(wordsReviewed, :zero) + :reviewed, " +
+                "updatedAt = :now, " +
+                "createdAt = if_not_exists(createdAt, :now)";
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+                .tableName(TABLE_NAME)
+                .key(key)
+                .updateExpression(updateExpression)
+                .expressionAttributeValues(values)
+                .build();
+
+        AwsClients.dynamoDb().updateItem(request);
+    }
+
+    /**
+     * Streak(연속 학습일) 업데이트
+     */
+    public void updateStreak(String userId, int currentStreak, int longestStreak, String lastStudyDate) {
+        String pk = StatsKey.userStatsPk(userId);
+        String sk = StatsKey.statsTotalSk();
+        String now = Instant.now().toString();
+
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("PK", AttributeValue.builder().s(pk).build());
+        key.put("SK", AttributeValue.builder().s(sk).build());
+
+        Map<String, AttributeValue> values = new HashMap<>();
+        values.put(":current", AttributeValue.builder().n(String.valueOf(currentStreak)).build());
+        values.put(":longest", AttributeValue.builder().n(String.valueOf(longestStreak)).build());
+        values.put(":lastDate", AttributeValue.builder().s(lastStudyDate).build());
+        values.put(":now", AttributeValue.builder().s(now).build());
+
+        String updateExpression = "SET " +
+                "currentStreak = :current, " +
+                "longestStreak = :longest, " +
+                "lastStudyDate = :lastDate, " +
+                "updatedAt = :now, " +
+                "createdAt = if_not_exists(createdAt, :now)";
+
+        UpdateItemRequest request = UpdateItemRequest.builder()
+                .tableName(TABLE_NAME)
+                .key(key)
+                .updateExpression(updateExpression)
+                .expressionAttributeValues(values)
+                .build();
+
+        AwsClients.dynamoDb().updateItem(request);
+        logger.info("Updated streak: userId={}, current={}, longest={}", userId, currentStreak, longestStreak);
+    }
+
+    /**
+     * 현재 연도-주차 반환 (예: 2026-W02)
+     */
+    private String getYearWeek() {
+        LocalDate now = LocalDate.now();
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        int week = now.get(weekFields.weekOfWeekBasedYear());
+        int year = now.get(weekFields.weekBasedYear());
+        return String.format("%d-W%02d", year, week);
+    }
+
+    /**
+     * 현재 연도-월 반환 (예: 2026-01)
+     */
+    private String getYearMonth() {
+        LocalDate now = LocalDate.now();
+        return String.format("%d-%02d", now.getYear(), now.getMonthValue());
+    }
+}


### PR DESCRIPTION
## Summary
- stats 도메인 패키지 생성 (vocabulary에서 분리)
- UserStats 모델: 일별/주별/월별/전체 학습 통계 저장
- UserStatsRepository: Atomic Counter 패턴으로 통계 업데이트

## Changes
- `domain/stats/model/UserStats.java`: 통계 데이터 모델
- `domain/stats/constants/StatsKey.java`: DynamoDB 키 상수
- `domain/stats/repository/UserStatsRepository.java`: Atomic Counter 기반 통계 업데이트

## Test plan
- [ ] 빌드 성공 확인
- [ ] Task #210 (StatsAggregator Lambda) 구현 후 통합 테스트

Related: Task #209, Story #205, Epic #204
