### PR TITLE
[TASK] #210, #211 DynamoDB Streams 기반 통계 자동 집계

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/StatsStreamHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/StatsStreamHandler.java
@@ -1,0 +1,143 @@
+package com.mzc.secondproject.serverless.domain.stats.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * DynamoDB Streams Handler for Stats Aggregation
+ * TestResult 저장 시 자동으로 통계 업데이트
+ */
+public class StatsStreamHandler implements RequestHandler<DynamodbEvent, Void> {
+
+    private static final Logger logger = LoggerFactory.getLogger(StatsStreamHandler.class);
+
+    private final UserStatsRepository userStatsRepository;
+
+    public StatsStreamHandler() {
+        this.userStatsRepository = new UserStatsRepository();
+    }
+
+    @Override
+    public Void handleRequest(DynamodbEvent event, Context context) {
+        logger.info("Received {} DynamoDB Stream records", event.getRecords().size());
+
+        for (DynamodbEvent.DynamodbStreamRecord record : event.getRecords()) {
+            try {
+                processRecord(record);
+            } catch (Exception e) {
+                logger.error("Failed to process record: {}", record.getEventID(), e);
+            }
+        }
+
+        return null;
+    }
+
+    private void processRecord(DynamodbEvent.DynamodbStreamRecord record) {
+        String eventName = record.getEventName();
+
+        // INSERT 이벤트만 처리 (새로운 테스트 결과)
+        if (!"INSERT".equals(eventName)) {
+            return;
+        }
+
+        Map<String, AttributeValue> newImage = record.getDynamodb().getNewImage();
+        if (newImage == null) {
+            return;
+        }
+
+        String pk = getStringValue(newImage, "PK");
+        String sk = getStringValue(newImage, "SK");
+
+        if (pk == null || sk == null) {
+            return;
+        }
+
+        // TestResult 레코드 확인: PK=TEST#{userId}, SK=RESULT#{timestamp}
+        if (pk.startsWith("TEST#") && sk.startsWith("RESULT#")) {
+            processTestResultInsert(newImage);
+        }
+    }
+
+    private void processTestResultInsert(Map<String, AttributeValue> newImage) {
+        String userId = getStringValue(newImage, "userId");
+        Integer correctAnswers = getNumberValue(newImage, "correctAnswers");
+        Integer incorrectAnswers = getNumberValue(newImage, "incorrectAnswers");
+        String testId = getStringValue(newImage, "testId");
+
+        if (userId == null || correctAnswers == null || incorrectAnswers == null) {
+            logger.warn("Missing required fields in TestResult record");
+            return;
+        }
+
+        logger.info("Processing TestResult: userId={}, testId={}, correct={}, incorrect={}",
+                userId, testId, correctAnswers, incorrectAnswers);
+
+        // 통계 업데이트
+        userStatsRepository.incrementTestStats(userId, correctAnswers, incorrectAnswers);
+
+        // Streak 업데이트
+        updateStudyStreak(userId);
+
+        logger.info("Stats updated for user: {}", userId);
+    }
+
+    private void updateStudyStreak(String userId) {
+        String today = LocalDate.now().toString();
+
+        Optional<com.mzc.secondproject.serverless.domain.stats.model.UserStats> totalStats =
+                userStatsRepository.findTotalStats(userId);
+
+        int currentStreak = 1;
+        int longestStreak = 1;
+
+        if (totalStats.isPresent()) {
+            var stats = totalStats.get();
+            String lastStudyDate = stats.getLastStudyDate();
+
+            if (lastStudyDate != null) {
+                LocalDate lastDate = LocalDate.parse(lastStudyDate);
+                LocalDate todayDate = LocalDate.now();
+
+                long daysDiff = todayDate.toEpochDay() - lastDate.toEpochDay();
+
+                if (daysDiff == 0) {
+                    // 오늘 이미 학습 - streak 유지
+                    return;
+                } else if (daysDiff == 1) {
+                    // 어제 학습 - streak 증가
+                    currentStreak = (stats.getCurrentStreak() != null ? stats.getCurrentStreak() : 0) + 1;
+                } else {
+                    // 연속 학습 끊김
+                    currentStreak = 1;
+                }
+            }
+
+            longestStreak = stats.getLongestStreak() != null ?
+                    Math.max(stats.getLongestStreak(), currentStreak) : currentStreak;
+        }
+
+        userStatsRepository.updateStreak(userId, currentStreak, longestStreak, today);
+    }
+
+    private String getStringValue(Map<String, AttributeValue> item, String key) {
+        AttributeValue value = item.get(key);
+        return value != null ? value.getS() : null;
+    }
+
+    private Integer getNumberValue(Map<String, AttributeValue> item, String key) {
+        AttributeValue value = item.get(key);
+        if (value != null && value.getN() != null) {
+            return Integer.parseInt(value.getN());
+        }
+        return null;
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/UserStatsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/UserStatsHandler.java
@@ -1,0 +1,183 @@
+package com.mzc.secondproject.serverless.domain.stats.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
+import com.mzc.secondproject.serverless.common.router.HandlerRouter;
+import com.mzc.secondproject.serverless.common.router.Route;
+import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 사용자 학습 통계 API Handler
+ */
+public class UserStatsHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserStatsHandler.class);
+
+    private final UserStatsRepository statsRepository;
+    private final HandlerRouter router;
+
+    public UserStatsHandler() {
+        this.statsRepository = new UserStatsRepository();
+        this.router = initRouter();
+    }
+
+    private HandlerRouter initRouter() {
+        return new HandlerRouter().addRoutes(
+                Route.getAuth("/stats/daily", this::getDailyStats),
+                Route.getAuth("/stats/weekly", this::getWeeklyStats),
+                Route.getAuth("/stats/monthly", this::getMonthlyStats),
+                Route.getAuth("/stats/total", this::getTotalStats),
+                Route.getAuth("/stats/history", this::getStatsHistory)
+        );
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request, Context context) {
+        logger.info("Received request: {} {}", request.getHttpMethod(), request.getPath());
+        return router.route(request);
+    }
+
+    /**
+     * 오늘의 통계 조회
+     */
+    private APIGatewayProxyResponseEvent getDailyStats(APIGatewayProxyRequestEvent request, String userId) {
+        Map<String, String> queryParams = request.getQueryStringParameters();
+        String date = queryParams != null && queryParams.get("date") != null ?
+                queryParams.get("date") : LocalDate.now().toString();
+
+        Optional<UserStats> stats = statsRepository.findDailyStats(userId, date);
+
+        return ResponseGenerator.ok("Daily stats retrieved", buildStatsResponse(stats, "DAILY", date));
+    }
+
+    /**
+     * 이번 주 통계 조회
+     */
+    private APIGatewayProxyResponseEvent getWeeklyStats(APIGatewayProxyRequestEvent request, String userId) {
+        Map<String, String> queryParams = request.getQueryStringParameters();
+        String yearWeek = queryParams != null && queryParams.get("week") != null ?
+                queryParams.get("week") : getCurrentYearWeek();
+
+        Optional<UserStats> stats = statsRepository.findWeeklyStats(userId, yearWeek);
+
+        return ResponseGenerator.ok("Weekly stats retrieved", buildStatsResponse(stats, "WEEKLY", yearWeek));
+    }
+
+    /**
+     * 이번 달 통계 조회
+     */
+    private APIGatewayProxyResponseEvent getMonthlyStats(APIGatewayProxyRequestEvent request, String userId) {
+        Map<String, String> queryParams = request.getQueryStringParameters();
+        String yearMonth = queryParams != null && queryParams.get("month") != null ?
+                queryParams.get("month") : getCurrentYearMonth();
+
+        Optional<UserStats> stats = statsRepository.findMonthlyStats(userId, yearMonth);
+
+        return ResponseGenerator.ok("Monthly stats retrieved", buildStatsResponse(stats, "MONTHLY", yearMonth));
+    }
+
+    /**
+     * 전체 통계 조회
+     */
+    private APIGatewayProxyResponseEvent getTotalStats(APIGatewayProxyRequestEvent request, String userId) {
+        Optional<UserStats> stats = statsRepository.findTotalStats(userId);
+
+        Map<String, Object> response = buildStatsResponse(stats, "TOTAL", "ALL");
+
+        // 전체 통계에는 streak 정보 추가
+        if (stats.isPresent()) {
+            UserStats s = stats.get();
+            response.put("currentStreak", s.getCurrentStreak() != null ? s.getCurrentStreak() : 0);
+            response.put("longestStreak", s.getLongestStreak() != null ? s.getLongestStreak() : 0);
+            response.put("lastStudyDate", s.getLastStudyDate());
+        } else {
+            response.put("currentStreak", 0);
+            response.put("longestStreak", 0);
+            response.put("lastStudyDate", null);
+        }
+
+        return ResponseGenerator.ok("Total stats retrieved", response);
+    }
+
+    /**
+     * 최근 일별 통계 히스토리 조회
+     */
+    private APIGatewayProxyResponseEvent getStatsHistory(APIGatewayProxyRequestEvent request, String userId) {
+        Map<String, String> queryParams = request.getQueryStringParameters();
+        String cursor = queryParams != null ? queryParams.get("cursor") : null;
+
+        int limit = 7;  // 기본 7일
+        if (queryParams != null && queryParams.get("limit") != null) {
+            limit = Math.min(Integer.parseInt(queryParams.get("limit")), 30);
+        }
+
+        PaginatedResult<UserStats> result = statsRepository.findRecentDailyStats(userId, limit, cursor);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("history", result.items());
+        response.put("nextCursor", result.nextCursor());
+        response.put("hasMore", result.hasMore());
+
+        return ResponseGenerator.ok("Stats history retrieved", response);
+    }
+
+    private Map<String, Object> buildStatsResponse(Optional<UserStats> stats, String periodType, String period) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("periodType", periodType);
+        response.put("period", period);
+
+        if (stats.isPresent()) {
+            UserStats s = stats.get();
+            response.put("testsCompleted", s.getTestsCompleted() != null ? s.getTestsCompleted() : 0);
+            response.put("questionsAnswered", s.getQuestionsAnswered() != null ? s.getQuestionsAnswered() : 0);
+            response.put("correctAnswers", s.getCorrectAnswers() != null ? s.getCorrectAnswers() : 0);
+            response.put("incorrectAnswers", s.getIncorrectAnswers() != null ? s.getIncorrectAnswers() : 0);
+            response.put("successRate", calculateSuccessRate(s));
+            response.put("newWordsLearned", s.getNewWordsLearned() != null ? s.getNewWordsLearned() : 0);
+            response.put("wordsReviewed", s.getWordsReviewed() != null ? s.getWordsReviewed() : 0);
+        } else {
+            response.put("testsCompleted", 0);
+            response.put("questionsAnswered", 0);
+            response.put("correctAnswers", 0);
+            response.put("incorrectAnswers", 0);
+            response.put("successRate", 0.0);
+            response.put("newWordsLearned", 0);
+            response.put("wordsReviewed", 0);
+        }
+
+        return response;
+    }
+
+    private double calculateSuccessRate(UserStats stats) {
+        int correct = stats.getCorrectAnswers() != null ? stats.getCorrectAnswers() : 0;
+        int total = stats.getQuestionsAnswered() != null ? stats.getQuestionsAnswered() : 0;
+        return total > 0 ? (correct * 100.0 / total) : 0.0;
+    }
+
+    private String getCurrentYearWeek() {
+        LocalDate now = LocalDate.now();
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        int week = now.get(weekFields.weekOfWeekBasedYear());
+        int year = now.get(weekFields.weekBasedYear());
+        return String.format("%d-W%02d", year, week);
+    }
+
+    private String getCurrentYearMonth() {
+        LocalDate now = LocalDate.now();
+        return String.format("%d-%02d", now.getYear(), now.getMonthValue());
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/service/StatsService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/service/StatsService.java
@@ -1,0 +1,113 @@
+package com.mzc.secondproject.serverless.domain.stats.service;
+
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * 학습 통계 서비스
+ * 테스트 결과 및 학습 이벤트를 통계로 집계
+ */
+public class StatsService {
+
+    private static final Logger logger = LoggerFactory.getLogger(StatsService.class);
+
+    private final UserStatsRepository userStatsRepository;
+
+    public StatsService() {
+        this.userStatsRepository = new UserStatsRepository();
+    }
+
+    /**
+     * 테스트 완료 시 통계 업데이트
+     */
+    public void recordTestCompletion(String userId, int correctAnswers, int incorrectAnswers) {
+        userStatsRepository.incrementTestStats(userId, correctAnswers, incorrectAnswers);
+        updateStudyStreak(userId);
+        logger.info("Recorded test completion: userId={}, correct={}, incorrect={}",
+                userId, correctAnswers, incorrectAnswers);
+    }
+
+    /**
+     * 단어 학습 완료 시 통계 업데이트
+     */
+    public void recordWordsLearned(String userId, int newWords, int reviewedWords) {
+        userStatsRepository.incrementWordsLearned(userId, newWords, reviewedWords);
+        updateStudyStreak(userId);
+        logger.info("Recorded words learned: userId={}, new={}, reviewed={}",
+                userId, newWords, reviewedWords);
+    }
+
+    /**
+     * 연속 학습일(Streak) 업데이트
+     */
+    private void updateStudyStreak(String userId) {
+        String today = LocalDate.now().toString();
+
+        Optional<UserStats> totalStats = userStatsRepository.findTotalStats(userId);
+
+        int currentStreak = 1;
+        int longestStreak = 1;
+
+        if (totalStats.isPresent()) {
+            UserStats stats = totalStats.get();
+            String lastStudyDate = stats.getLastStudyDate();
+
+            if (lastStudyDate != null) {
+                LocalDate lastDate = LocalDate.parse(lastStudyDate);
+                LocalDate todayDate = LocalDate.now();
+
+                long daysDiff = todayDate.toEpochDay() - lastDate.toEpochDay();
+
+                if (daysDiff == 0) {
+                    // 오늘 이미 학습함 - streak 유지
+                    return;
+                } else if (daysDiff == 1) {
+                    // 어제 학습함 - streak 증가
+                    currentStreak = (stats.getCurrentStreak() != null ? stats.getCurrentStreak() : 0) + 1;
+                } else {
+                    // 연속 학습 끊김 - streak 리셋
+                    currentStreak = 1;
+                }
+            }
+
+            longestStreak = stats.getLongestStreak() != null ?
+                    Math.max(stats.getLongestStreak(), currentStreak) : currentStreak;
+        }
+
+        userStatsRepository.updateStreak(userId, currentStreak, longestStreak, today);
+        logger.info("Updated streak: userId={}, current={}, longest={}", userId, currentStreak, longestStreak);
+    }
+
+    /**
+     * 일별 통계 조회
+     */
+    public Optional<UserStats> getDailyStats(String userId, String date) {
+        return userStatsRepository.findDailyStats(userId, date);
+    }
+
+    /**
+     * 주별 통계 조회
+     */
+    public Optional<UserStats> getWeeklyStats(String userId, String yearWeek) {
+        return userStatsRepository.findWeeklyStats(userId, yearWeek);
+    }
+
+    /**
+     * 월별 통계 조회
+     */
+    public Optional<UserStats> getMonthlyStats(String userId, String yearMonth) {
+        return userStatsRepository.findMonthlyStats(userId, yearMonth);
+    }
+
+    /**
+     * 전체 통계 조회
+     */
+    public Optional<UserStats> getTotalStats(String userId) {
+        return userStatsRepository.findTotalStats(userId);
+    }
+}

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -798,6 +798,90 @@ Resources:
               Authorizer: NONE
 
   #############################################
+  # Stats Lambda Functions (DynamoDB Streams)
+  #############################################
+
+  # DynamoDB Streams 트리거 - 테스트 결과 저장 시 통계 자동 업데이트
+  StatsStreamFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: group2-englishstudy-stats-stream-handler
+      CodeUri: .
+      Handler: com.mzc.secondproject.serverless.domain.stats.handler.StatsStreamHandler::handleRequest
+      Description: Process DynamoDB Streams for stats aggregation
+      Timeout: 60
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref VocabTable
+      Events:
+        DynamoDBStream:
+          Type: DynamoDB
+          Properties:
+            Stream: !GetAtt VocabTable.StreamArn
+            StartingPosition: TRIM_HORIZON
+            BatchSize: 100
+            FilterCriteria:
+              Filters:
+                - Pattern: '{"eventName": ["INSERT"], "dynamodb": {"NewImage": {"PK": {"S": [{"prefix": "TEST#"}]}}}}'
+
+  # 사용자 통계 조회 API Handler
+  UserStatsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: group2-englishstudy-user-stats-handler
+      CodeUri: .
+      Handler: com.mzc.secondproject.serverless.domain.stats.handler.UserStatsHandler::handleRequest
+      Description: Handle user learning statistics API
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref VocabTable
+      Events:
+        GetDailyStats:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /stats/daily
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+        GetWeeklyStats:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /stats/weekly
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+        GetMonthlyStats:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /stats/monthly
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+        GetTotalStats:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /stats/total
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+        GetStatsHistory:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /stats/history
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+
+  #############################################
   # DynamoDB Tables
   #############################################
 
@@ -895,6 +979,8 @@ Resources:
     Properties:
       TableName: group2-englishstudy-vocab
       BillingMode: PAY_PER_REQUEST
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE
       AttributeDefinitions:
         - AttributeName: PK
           AttributeType: S


### PR DESCRIPTION
## Summary
- DynamoDB Streams를 통한 통계 자동 집계 구현
- 클라이언트는 기존처럼 테스트만 제출하면 통계가 자동 업데이트

## Changes
### Lambda Functions
- `StatsStreamHandler`: DynamoDB Streams 이벤트 처리
- `UserStatsHandler`: 통계 조회 API (5개 엔드포인트)
- `StatsService`: 통계 비즈니스 로직

### Infrastructure (template.yaml)
- VocabTable에 DynamoDB Streams 활성화 (NEW_IMAGE)
- FilterCriteria로 TEST# 레코드만 필터링
- StatsStreamFunction, UserStatsFunction Lambda 추가

## API Endpoints
- `GET /stats/daily` - 일별 통계
- `GET /stats/weekly` - 주별 통계
- `GET /stats/monthly` - 월별 통계
- `GET /stats/total` - 전체 통계 + Streak
- `GET /stats/history` - 최근 일별 히스토리

## Test plan
- [ ] 배포 후 테스트 제출
- [ ] 통계 API 호출하여 업데이트 확인

Related: Task #210, Task #211, Story #205, Epic #204