### PR TITLE
[STORY] #206 EventBridge Scheduler 기반 정기 작업

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/enums/WordStatus.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/enums/WordStatus.java
@@ -6,7 +6,8 @@ public enum WordStatus {
     NEW("new", "새 단어"),
     LEARNING("learning", "학습 중"),
     REVIEWING("reviewing", "복습 중"),
-    MASTERED("mastered", "완료");
+    MASTERED("mastered", "완료"),
+    UNKNOWN("unknown", "모르겠음");
 
     private final String code;
     private final String displayName;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/TestHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/TestHandler.java
@@ -40,7 +40,8 @@ public class TestHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
                 Route.postAuth("/test/start", this::startTest),
                 Route.postAuth("/test/submit", this::submitAnswer),
                 Route.getAuth("/test/results/{testId}", this::getTestResultDetail),
-                Route.getAuth("/test/results", this::getTestResults)
+                Route.getAuth("/test/results", this::getTestResults),
+                Route.getAuth("/test/tested-words", this::getTestedWords)
         );
     }
 
@@ -129,5 +130,29 @@ public class TestHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
         result.put("completedAt", detail.testResult().getCompletedAt());
 
         return ResponseGenerator.ok("Test result detail retrieved", result);
+    }
+
+    private APIGatewayProxyResponseEvent getTestedWords(APIGatewayProxyRequestEvent request, String userId) {
+        Map<String, String> queryParams = request.getQueryStringParameters();
+
+        int recentTests = 10;
+        int limit = 50;
+
+        if (queryParams != null) {
+            if (queryParams.get("recentTests") != null) {
+                recentTests = Math.min(Integer.parseInt(queryParams.get("recentTests")), 50);
+            }
+            if (queryParams.get("limit") != null) {
+                limit = Math.min(Integer.parseInt(queryParams.get("limit")), 100);
+            }
+        }
+
+        TestQueryService.TestedWordsResult result = queryService.getTestedWords(userId, recentTests, limit);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("testedWords", result.words());
+        response.put("totalCount", result.totalCount());
+
+        return ResponseGenerator.ok("Tested words retrieved", response);
     }
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/model/TestResult.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/model/TestResult.java
@@ -41,6 +41,9 @@ public class TestResult {
     private Integer incorrectAnswers;
     private Double successRate;     // 성공률 (%)
 
+    // 시험에 출제된 전체 단어 목록
+    private List<String> testedWordIds;
+
     // 오답 단어 목록
     private List<String> incorrectWordIds;
 

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
@@ -160,6 +160,7 @@ public class TestCommandService {
                 .correctAnswers(correctCount)
                 .incorrectAnswers(incorrectCount)
                 .successRate(successRate)
+                .testedWordIds(wordIds)
                 .incorrectWordIds(incorrectWordIds)
                 .startedAt(startedAt)
                 .completedAt(now)

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestQueryService.java
@@ -8,8 +8,11 @@ import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordReposit
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Test 조회 전용 서비스 (CQRS Query)
@@ -47,5 +50,34 @@ public class TestQueryService {
         return Optional.of(new TestResultDetail(testResult, incorrectWords));
     }
 
+    /**
+     * 시험에 나온 단어 조회
+     * 최근 테스트 결과들에서 출제된 단어들을 조회
+     */
+    public TestedWordsResult getTestedWords(String userId, int recentTests, int limit) {
+        PaginatedResult<TestResult> results = testResultRepository.findByUserIdWithPagination(userId, recentTests, null);
+
+        Set<String> testedWordIds = new LinkedHashSet<>();
+        for (TestResult result : results.items()) {
+            if (result.getTestedWordIds() != null) {
+                testedWordIds.addAll(result.getTestedWordIds());
+            }
+        }
+
+        if (testedWordIds.isEmpty()) {
+            return new TestedWordsResult(new ArrayList<>(), testedWordIds.size());
+        }
+
+        List<String> wordIdList = new ArrayList<>(testedWordIds);
+        if (wordIdList.size() > limit) {
+            wordIdList = wordIdList.subList(0, limit);
+        }
+
+        List<Word> words = wordRepository.findByIds(wordIdList);
+        return new TestedWordsResult(words, testedWordIds.size());
+    }
+
     public record TestResultDetail(TestResult testResult, List<Word> incorrectWords) {}
+
+    public record TestedWordsResult(List<Word> words, int totalCount) {}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/state/WordStateFactory.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/state/WordStateFactory.java
@@ -31,7 +31,7 @@ public final class WordStateFactory {
      */
     public static WordState fromStatus(WordStatus status) {
         return switch (status) {
-            case NEW -> NewState.getInstance();
+            case NEW, UNKNOWN -> NewState.getInstance();
             case LEARNING -> LearningState.getInstance();
             case REVIEWING -> ReviewingState.getInstance();
             case MASTERED -> MasteredState.getInstance();

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -577,6 +577,14 @@ Resources:
             Method: PUT
             Auth:
               Authorizer: CognitoAuthorizer
+        UpdateUserWordStatus:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /vocab/user-words/{wordId}/status
+            Method: PUT
+            Auth:
+              Authorizer: CognitoAuthorizer
 
   WordGroupFunction:
     Type: AWS::Serverless::Function
@@ -725,6 +733,14 @@ Resources:
           Properties:
             RestApiId: !Ref MainApi
             Path: /vocab/test/results/{testId}
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+        GetTestedWords:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /vocab/test/tested-words
             Method: GET
             Auth:
               Authorizer: CognitoAuthorizer


### PR DESCRIPTION
## Summary
매일 자정 EventBridge Scheduler로 단어 학습 통계 집계

## Features
### ScheduledStatsHandler
- 매일 KST 00:00 (UTC 15:00) 실행
- 일별 단어 학습 통계 집계
  - `newWordsLearned`: 새로 학습한 단어 수
  - `wordsReviewed`: 복습한 단어 수
- Streak 체크 및 리셋
  - 어제 학습 안 한 사용자의 streak을 0으로 리셋

### Infrastructure
- EventBridge Schedule Rule 추가
- Lambda Timeout: 300초 (Scan 작업용)
- Lambda Memory: 1024MB

## Architecture
```
EventBridge Scheduler (매일 자정)
    ↓
ScheduledStatsHandler
    ↓
DailyStudy 테이블 스캔 → UserStats 업데이트
```

## Test plan
- [ ] 배포 후 Lambda 수동 테스트
- [ ] CloudWatch Logs 확인

Related: Story #206, Epic #204