### PR TITLE
[STORY] 게임 상태 관리 및 라운드 진행 #223

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/GameStatus.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/GameStatus.java
@@ -1,0 +1,49 @@
+package com.mzc.secondproject.serverless.domain.chatting.enums;
+
+import java.util.Arrays;
+
+public enum GameStatus {
+	NONE("none", "게임 없음"),
+	WAITING("waiting", "게임 대기 중"),
+	PLAYING("playing", "게임 진행 중"),
+	ROUND_END("round_end", "라운드 종료"),
+	FINISHED("finished", "게임 종료");
+
+	private final String code;
+	private final String displayName;
+
+	GameStatus(String code, String displayName) {
+		this.code = code;
+		this.displayName = displayName;
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public static boolean isValid(String value) {
+		if (value == null) return false;
+		return Arrays.stream(values())
+				.anyMatch(status -> status.name().equalsIgnoreCase(value) || status.code.equalsIgnoreCase(value));
+	}
+
+	public static GameStatus fromString(String value) {
+		if (value == null) return NONE;
+		return Arrays.stream(values())
+				.filter(status -> status.name().equalsIgnoreCase(value) || status.code.equalsIgnoreCase(value))
+				.findFirst()
+				.orElse(NONE);
+	}
+
+	public boolean isGameActive() {
+		return this == PLAYING || this == ROUND_END;
+	}
+
+	public boolean canStartGame() {
+		return this == NONE || this == FINISHED;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameRound.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameRound.java
@@ -1,0 +1,69 @@
+package com.mzc.secondproject.serverless.domain.chatting.model;
+
+import lombok.*;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 캐치마인드 게임 라운드 기록
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@DynamoDbBean
+public class GameRound {
+
+	private String pk;              // ROOM#{roomId}#GAME
+	private String sk;              // ROUND#{roundNumber}
+
+	private String roomId;
+	private Integer roundNumber;
+	private String drawerId;        // 출제자 userId
+	private String wordId;          // 제시어 wordId
+	private String word;            // 제시어 (korean)
+	private String wordEnglish;     // 제시어 (english)
+
+	private List<String> correctGuessers;       // 정답 맞춘 순서
+	private Map<String, Long> guessTimes;       // userId -> 정답까지 걸린 시간(ms)
+	private Map<String, Integer> roundScores;   // userId -> 이 라운드 획득 점수
+
+	private Long startTime;         // 라운드 시작 시간 (Unix timestamp ms)
+	private Long endTime;           // 라운드 종료 시간
+	private String endReason;       // TIME_UP, ALL_CORRECT, SKIP
+
+	private Boolean hintUsed;       // 힌트 사용 여부
+	private String createdAt;
+
+	@DynamoDbPartitionKey
+	@DynamoDbAttribute("PK")
+	public String getPk() {
+		return pk;
+	}
+
+	@DynamoDbSortKey
+	@DynamoDbAttribute("SK")
+	public String getSk() {
+		return sk;
+	}
+
+	/**
+	 * 라운드가 진행 중인지 확인
+	 */
+	@DynamoDbIgnore
+	public boolean isActive() {
+		return endTime == null;
+	}
+
+	/**
+	 * 경과 시간 계산 (ms)
+	 */
+	@DynamoDbIgnore
+	public long getElapsedTime() {
+		if (startTime == null) return 0;
+		long end = endTime != null ? endTime : System.currentTimeMillis();
+		return end - startTime;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameRoundRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameRoundRepository.java
@@ -1,0 +1,79 @@
+package com.mzc.secondproject.serverless.domain.chatting.repository;
+
+import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.domain.chatting.model.GameRound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 게임 라운드 저장소
+ */
+public class GameRoundRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(GameRoundRepository.class);
+	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+
+	private final DynamoDbTable<GameRound> table;
+
+	public GameRoundRepository() {
+		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(GameRound.class));
+	}
+
+	public GameRound save(GameRound gameRound) {
+		logger.info("Saving game round: roomId={}, round={}", gameRound.getRoomId(), gameRound.getRoundNumber());
+		table.putItem(gameRound);
+		return gameRound;
+	}
+
+	public Optional<GameRound> findByRoomIdAndRound(String roomId, Integer roundNumber) {
+		Key key = Key.builder()
+				.partitionValue("ROOM#" + roomId + "#GAME")
+				.sortValue("ROUND#" + roundNumber)
+				.build();
+
+		GameRound round = table.getItem(key);
+		return Optional.ofNullable(round);
+	}
+
+	/**
+	 * 특정 게임의 모든 라운드 조회
+	 */
+	public List<GameRound> findByRoomId(String roomId) {
+		QueryConditional queryConditional = QueryConditional
+				.keyEqualTo(Key.builder()
+						.partitionValue("ROOM#" + roomId + "#GAME")
+						.build());
+
+		QueryEnhancedRequest request = QueryEnhancedRequest.builder()
+				.queryConditional(queryConditional)
+				.build();
+
+		return table.query(request).stream()
+				.flatMap(page -> page.items().stream())
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * 특정 게임의 모든 라운드 삭제
+	 */
+	public void deleteByRoomId(String roomId) {
+		List<GameRound> rounds = findByRoomId(roomId);
+		for (GameRound round : rounds) {
+			Key key = Key.builder()
+					.partitionValue(round.getPk())
+					.sortValue(round.getSk())
+					.build();
+			table.deleteItem(key);
+		}
+		logger.info("Deleted {} rounds for roomId={}", rounds.size(), roomId);
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/CommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/CommandService.java
@@ -22,10 +22,12 @@ public class CommandService {
 
 	private final ConnectionRepository connectionRepository;
 	private final ChatRoomRepository chatRoomRepository;
+	private final GameService gameService;
 
 	public CommandService() {
 		this.connectionRepository = new ConnectionRepository();
 		this.chatRoomRepository = new ChatRoomRepository();
+		this.gameService = new GameService();
 	}
 
 	/**
@@ -79,54 +81,30 @@ public class CommandService {
 	 * /start - 게임 시작
 	 */
 	private CommandResult handleStartCommand(String roomId, String userId) {
-		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		GameService.GameStartResult result = gameService.startGame(roomId, userId);
 
-		if (connections.size() < 2) {
-			return CommandResult.error("최소 2명 이상 접속해야 게임을 시작할 수 있습니다. (현재: " + connections.size() + "명)");
+		if (!result.success()) {
+			return CommandResult.error(result.error());
 		}
 
-		Optional<ChatRoom> optRoom = chatRoomRepository.findById(roomId);
-		if (optRoom.isEmpty()) {
-			return CommandResult.error("채팅방을 찾을 수 없습니다.");
-		}
+		String message = String.format("""
+				🎮 게임 시작!
+				총 %d 라운드
 
-		ChatRoom room = optRoom.get();
+				라운드 1 시작!
+				출제자: %s
+				""",
+				result.room().getTotalRounds(),
+				result.room().getCurrentDrawerId());
 
-		// 이미 게임 중인지 확인
-		if (room.getGameStatus() != null && !"NONE".equals(room.getGameStatus()) && !"FINISHED".equals(room.getGameStatus())) {
-			return CommandResult.error("이미 게임이 진행 중입니다.");
-		}
-
-		// TODO: GameService.startGame() 호출 (Story #223에서 구현)
-		return CommandResult.success(MessageType.GAME_START, "게임이 곧 시작됩니다! 준비하세요.");
+		return CommandResult.success(MessageType.GAME_START, message, result);
 	}
 
 	/**
 	 * /stop - 게임 중단
 	 */
 	private CommandResult handleStopCommand(String roomId, String userId) {
-		Optional<ChatRoom> optRoom = chatRoomRepository.findById(roomId);
-		if (optRoom.isEmpty()) {
-			return CommandResult.error("채팅방을 찾을 수 없습니다.");
-		}
-
-		ChatRoom room = optRoom.get();
-
-		// 게임 진행 중인지 확인
-		if (room.getGameStatus() == null || "NONE".equals(room.getGameStatus()) || "FINISHED".equals(room.getGameStatus())) {
-			return CommandResult.error("진행 중인 게임이 없습니다.");
-		}
-
-		// 권한 확인: 게임 시작한 사람 또는 방장
-		boolean isOwner = userId.equals(room.getCreatedBy());
-		boolean isGameStarter = userId.equals(room.getGameStartedBy());
-
-		if (!isOwner && !isGameStarter) {
-			return CommandResult.error("게임을 중단할 권한이 없습니다. (방장 또는 게임 시작자만 가능)");
-		}
-
-		// TODO: GameService.stopGame() 호출 (Story #223에서 구현)
-		return CommandResult.success(MessageType.GAME_END, "게임이 중단되었습니다.");
+		return gameService.stopGame(roomId, userId);
 	}
 
 	/**
@@ -161,59 +139,14 @@ public class CommandService {
 	 * /skip - 라운드 스킵 (출제자만)
 	 */
 	private CommandResult handleSkipCommand(String roomId, String userId) {
-		Optional<ChatRoom> optRoom = chatRoomRepository.findById(roomId);
-		if (optRoom.isEmpty()) {
-			return CommandResult.error("채팅방을 찾을 수 없습니다.");
-		}
-
-		ChatRoom room = optRoom.get();
-
-		if (!"PLAYING".equals(room.getGameStatus())) {
-			return CommandResult.error("게임이 진행 중이 아닙니다.");
-		}
-
-		if (!userId.equals(room.getCurrentDrawerId())) {
-			return CommandResult.error("출제자만 라운드를 스킵할 수 있습니다.");
-		}
-
-		// TODO: GameService.skipRound() 호출 (Story #223에서 구현)
-		return CommandResult.success(MessageType.ROUND_END, "라운드가 스킵되었습니다. 정답: " + room.getCurrentWord());
+		return gameService.skipRound(roomId, userId);
 	}
 
 	/**
 	 * /hint - 힌트 제공 (출제자만)
 	 */
 	private CommandResult handleHintCommand(String roomId, String userId) {
-		Optional<ChatRoom> optRoom = chatRoomRepository.findById(roomId);
-		if (optRoom.isEmpty()) {
-			return CommandResult.error("채팅방을 찾을 수 없습니다.");
-		}
-
-		ChatRoom room = optRoom.get();
-
-		if (!"PLAYING".equals(room.getGameStatus())) {
-			return CommandResult.error("게임이 진행 중이 아닙니다.");
-		}
-
-		if (!userId.equals(room.getCurrentDrawerId())) {
-			return CommandResult.error("출제자만 힌트를 제공할 수 있습니다.");
-		}
-
-		// 힌트 사용 여부 체크
-		if (Boolean.TRUE.equals(room.getHintUsed())) {
-			return CommandResult.error("이번 라운드에서 이미 힌트를 사용했습니다.");
-		}
-
-		String currentWord = room.getCurrentWord();
-		if (currentWord == null || currentWord.isEmpty()) {
-			return CommandResult.error("제시어가 설정되지 않았습니다.");
-		}
-
-		// 첫 글자 힌트
-		String hint = currentWord.charAt(0) + "○".repeat(currentWord.length() - 1);
-
-		// TODO: hintUsed 플래그 업데이트 (Story #223에서 구현)
-		return CommandResult.success(MessageType.HINT, "💡 힌트: " + hint);
+		return gameService.provideHint(roomId, userId);
 	}
 
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
@@ -1,0 +1,485 @@
+package com.mzc.secondproject.serverless.domain.chatting.service;
+
+import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
+import com.mzc.secondproject.serverless.domain.chatting.dto.response.CommandResult;
+import com.mzc.secondproject.serverless.domain.chatting.enums.GameStatus;
+import com.mzc.secondproject.serverless.domain.chatting.enums.MessageType;
+import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
+import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
+import com.mzc.secondproject.serverless.domain.chatting.model.GameRound;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ChatRoomRepository;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
+import com.mzc.secondproject.serverless.domain.chatting.repository.GameRoundRepository;
+import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
+import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 캐치마인드 게임 로직 서비스
+ */
+public class GameService {
+
+	private static final Logger logger = LoggerFactory.getLogger(GameService.class);
+	private static final int DEFAULT_TOTAL_ROUNDS = 5;
+	private static final int DEFAULT_ROUND_TIME_LIMIT = 60; // 초
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final ConnectionRepository connectionRepository;
+	private final GameRoundRepository gameRoundRepository;
+	private final WordRepository wordRepository;
+
+	public GameService() {
+		this.chatRoomRepository = new ChatRoomRepository();
+		this.connectionRepository = new ConnectionRepository();
+		this.gameRoundRepository = new GameRoundRepository();
+		this.wordRepository = new WordRepository();
+	}
+
+	/**
+	 * 게임 시작
+	 */
+	public GameStartResult startGame(String roomId, String userId) {
+		ChatRoom room = chatRoomRepository.findById(roomId)
+				.orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+		// 이미 게임 중인지 확인
+		GameStatus currentStatus = GameStatus.fromString(room.getGameStatus());
+		if (!currentStatus.canStartGame()) {
+			return GameStartResult.error("이미 게임이 진행 중입니다.");
+		}
+
+		// 접속자 확인
+		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		if (connections.size() < 2) {
+			return GameStartResult.error("최소 2명 이상 접속해야 게임을 시작할 수 있습니다.");
+		}
+
+		// 출제 순서 생성 (랜덤 셔플)
+		List<String> drawerOrder = connections.stream()
+				.map(Connection::getUserId)
+				.collect(Collectors.toList());
+		Collections.shuffle(drawerOrder);
+
+		// 제시어 추출 (난이도별)
+		String level = room.getLevel() != null ? room.getLevel() : "beginner";
+		List<Word> words = getRandomWords(level, DEFAULT_TOTAL_ROUNDS);
+
+		if (words.size() < DEFAULT_TOTAL_ROUNDS) {
+			return GameStartResult.error("단어가 부족합니다. 관리자에게 문의하세요.");
+		}
+
+		// 게임 상태 업데이트
+		room.setGameStatus(GameStatus.PLAYING.name());
+		room.setGameStartedBy(userId);
+		room.setCurrentRound(1);
+		room.setTotalRounds(DEFAULT_TOTAL_ROUNDS);
+		room.setDrawerOrder(drawerOrder);
+		room.setScores(new HashMap<>());
+		room.setRoundTimeLimit(DEFAULT_ROUND_TIME_LIMIT);
+
+		// 첫 라운드 설정
+		String firstDrawer = drawerOrder.get(0);
+		Word firstWord = words.get(0);
+		room.setCurrentDrawerId(firstDrawer);
+		room.setCurrentWordId(firstWord.getWordId());
+		room.setCurrentWord(firstWord.getKorean());
+		room.setRoundStartTime(System.currentTimeMillis());
+		room.setHintUsed(false);
+		room.setCorrectGuessers(new ArrayList<>());
+
+		chatRoomRepository.save(room);
+
+		// 첫 라운드 기록 생성
+		GameRound firstRound = GameRound.builder()
+				.pk("ROOM#" + roomId + "#GAME")
+				.sk("ROUND#1")
+				.roomId(roomId)
+				.roundNumber(1)
+				.drawerId(firstDrawer)
+				.wordId(firstWord.getWordId())
+				.word(firstWord.getKorean())
+				.wordEnglish(firstWord.getEnglish())
+				.startTime(System.currentTimeMillis())
+				.hintUsed(false)
+				.correctGuessers(new ArrayList<>())
+				.guessTimes(new HashMap<>())
+				.roundScores(new HashMap<>())
+				.createdAt(Instant.now().toString())
+				.build();
+
+		gameRoundRepository.save(firstRound);
+
+		logger.info("Game started: roomId={}, starter={}, rounds={}", roomId, userId, DEFAULT_TOTAL_ROUNDS);
+
+		return GameStartResult.success(room, firstWord, drawerOrder);
+	}
+
+	/**
+	 * 게임 종료
+	 */
+	public CommandResult stopGame(String roomId, String userId) {
+		ChatRoom room = chatRoomRepository.findById(roomId)
+				.orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+		GameStatus currentStatus = GameStatus.fromString(room.getGameStatus());
+		if (!currentStatus.isGameActive()) {
+			return CommandResult.error("진행 중인 게임이 없습니다.");
+		}
+
+		// 권한 확인
+		boolean isOwner = userId.equals(room.getCreatedBy());
+		boolean isGameStarter = userId.equals(room.getGameStartedBy());
+
+		if (!isOwner && !isGameStarter) {
+			return CommandResult.error("게임을 중단할 권한이 없습니다.");
+		}
+
+		// 게임 종료 처리
+		return finishGame(room, "STOPPED");
+	}
+
+	/**
+	 * 정답 체크
+	 */
+	public AnswerCheckResult checkAnswer(String roomId, String userId, String answer) {
+		ChatRoom room = chatRoomRepository.findById(roomId)
+				.orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+		// 게임 진행 중인지 확인
+		if (!GameStatus.PLAYING.name().equals(room.getGameStatus())) {
+			return AnswerCheckResult.gameNotPlaying();
+		}
+
+		// 출제자는 정답 체크 제외
+		if (userId.equals(room.getCurrentDrawerId())) {
+			return AnswerCheckResult.drawerCannotGuess();
+		}
+
+		// 이미 맞춘 사람인지 확인
+		if (room.getCorrectGuessers() != null && room.getCorrectGuessers().contains(userId)) {
+			return AnswerCheckResult.alreadyGuessedCorrect();
+		}
+
+		// 정답 체크
+		String currentWord = room.getCurrentWord();
+		if (!isCorrectAnswer(answer, currentWord)) {
+			return AnswerCheckResult.wrongAnswer();
+		}
+
+		// 정답 처리
+		long elapsedTime = System.currentTimeMillis() - room.getRoundStartTime();
+		int score = calculateScore(room, elapsedTime, userId);
+
+		// 정답자 목록에 추가
+		if (room.getCorrectGuessers() == null) {
+			room.setCorrectGuessers(new ArrayList<>());
+		}
+		room.getCorrectGuessers().add(userId);
+
+		// 점수 업데이트
+		if (room.getScores() == null) {
+			room.setScores(new HashMap<>());
+		}
+		room.getScores().merge(userId, score, Integer::sum);
+
+		// 출제자 점수도 추가
+		room.getScores().merge(room.getCurrentDrawerId(), 5, Integer::sum);
+
+		chatRoomRepository.save(room);
+
+		// 라운드 기록 업데이트
+		updateRoundRecord(roomId, room.getCurrentRound(), userId, elapsedTime, score);
+
+		// 전원 정답 체크
+		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		int nonDrawerCount = (int) connections.stream()
+				.filter(c -> !c.getUserId().equals(room.getCurrentDrawerId()))
+				.count();
+
+		boolean allCorrect = room.getCorrectGuessers().size() >= nonDrawerCount;
+
+		logger.info("Answer correct: roomId={}, userId={}, score={}, allCorrect={}",
+				roomId, userId, score, allCorrect);
+
+		return AnswerCheckResult.correctAnswer(score, elapsedTime, allCorrect, room.getScores());
+	}
+
+	/**
+	 * 라운드 스킵
+	 */
+	public CommandResult skipRound(String roomId, String userId) {
+		ChatRoom room = chatRoomRepository.findById(roomId)
+				.orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+		if (!GameStatus.PLAYING.name().equals(room.getGameStatus())) {
+			return CommandResult.error("게임이 진행 중이 아닙니다.");
+		}
+
+		if (!userId.equals(room.getCurrentDrawerId())) {
+			return CommandResult.error("출제자만 라운드를 스킵할 수 있습니다.");
+		}
+
+		return endRound(room, "SKIP");
+	}
+
+	/**
+	 * 힌트 제공
+	 */
+	public CommandResult provideHint(String roomId, String userId) {
+		ChatRoom room = chatRoomRepository.findById(roomId)
+				.orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+		if (!GameStatus.PLAYING.name().equals(room.getGameStatus())) {
+			return CommandResult.error("게임이 진행 중이 아닙니다.");
+		}
+
+		if (!userId.equals(room.getCurrentDrawerId())) {
+			return CommandResult.error("출제자만 힌트를 제공할 수 있습니다.");
+		}
+
+		if (Boolean.TRUE.equals(room.getHintUsed())) {
+			return CommandResult.error("이번 라운드에서 이미 힌트를 사용했습니다.");
+		}
+
+		String currentWord = room.getCurrentWord();
+		String hint = currentWord.charAt(0) + "○".repeat(currentWord.length() - 1);
+
+		room.setHintUsed(true);
+		chatRoomRepository.save(room);
+
+		// 라운드 기록 업데이트
+		gameRoundRepository.findByRoomIdAndRound(roomId, room.getCurrentRound())
+				.ifPresent(round -> {
+					round.setHintUsed(true);
+					gameRoundRepository.save(round);
+				});
+
+		return CommandResult.success(MessageType.HINT, "💡 힌트: " + hint);
+	}
+
+	/**
+	 * 라운드 종료 처리
+	 */
+	public CommandResult endRound(ChatRoom room, String reason) {
+		String roomId = room.getRoomId();
+		Integer currentRound = room.getCurrentRound();
+		String answer = room.getCurrentWord();
+
+		// 라운드 기록 종료
+		gameRoundRepository.findByRoomIdAndRound(roomId, currentRound)
+				.ifPresent(round -> {
+					round.setEndTime(System.currentTimeMillis());
+					round.setEndReason(reason);
+					gameRoundRepository.save(round);
+				});
+
+		// 다음 라운드로 진행
+		if (currentRound >= room.getTotalRounds()) {
+			return finishGame(room, "COMPLETED");
+		}
+
+		// 다음 라운드 준비
+		int nextRound = currentRound + 1;
+		int drawerIndex = (nextRound - 1) % room.getDrawerOrder().size();
+		String nextDrawer = room.getDrawerOrder().get(drawerIndex);
+
+		// 다음 단어 추출
+		String level = room.getLevel() != null ? room.getLevel() : "beginner";
+		List<Word> words = getRandomWords(level, 1);
+		if (words.isEmpty()) {
+			return finishGame(room, "NO_WORDS");
+		}
+		Word nextWord = words.get(0);
+
+		// 상태 업데이트
+		room.setCurrentRound(nextRound);
+		room.setCurrentDrawerId(nextDrawer);
+		room.setCurrentWordId(nextWord.getWordId());
+		room.setCurrentWord(nextWord.getKorean());
+		room.setRoundStartTime(System.currentTimeMillis());
+		room.setHintUsed(false);
+		room.setCorrectGuessers(new ArrayList<>());
+
+		chatRoomRepository.save(room);
+
+		// 다음 라운드 기록 생성
+		GameRound nextRoundRecord = GameRound.builder()
+				.pk("ROOM#" + roomId + "#GAME")
+				.sk("ROUND#" + nextRound)
+				.roomId(roomId)
+				.roundNumber(nextRound)
+				.drawerId(nextDrawer)
+				.wordId(nextWord.getWordId())
+				.word(nextWord.getKorean())
+				.wordEnglish(nextWord.getEnglish())
+				.startTime(System.currentTimeMillis())
+				.hintUsed(false)
+				.correctGuessers(new ArrayList<>())
+				.guessTimes(new HashMap<>())
+				.roundScores(new HashMap<>())
+				.createdAt(Instant.now().toString())
+				.build();
+
+		gameRoundRepository.save(nextRoundRecord);
+
+		String message = String.format("라운드 %d 종료! 정답: %s\n\n라운드 %d 시작! 출제자: %s",
+				currentRound, answer, nextRound, nextDrawer);
+
+		logger.info("Round ended: roomId={}, round={}, reason={}", roomId, currentRound, reason);
+
+		return CommandResult.success(MessageType.ROUND_END, message,
+				Map.of("answer", answer, "nextRound", nextRound, "nextDrawer", nextDrawer, "nextWord", nextWord));
+	}
+
+	/**
+	 * 게임 완전 종료
+	 */
+	private CommandResult finishGame(ChatRoom room, String reason) {
+		room.setGameStatus(GameStatus.FINISHED.name());
+		chatRoomRepository.save(room);
+
+		// 최종 점수 정렬
+		StringBuilder sb = new StringBuilder("🎮 게임 종료!\n\n📊 최종 순위:\n");
+		if (room.getScores() != null && !room.getScores().isEmpty()) {
+			List<Map.Entry<String, Integer>> sorted = room.getScores().entrySet().stream()
+					.sorted((a, b) -> b.getValue().compareTo(a.getValue()))
+					.toList();
+
+			int rank = 1;
+			for (Map.Entry<String, Integer> entry : sorted) {
+				String medal = switch (rank) {
+					case 1 -> "🥇";
+					case 2 -> "🥈";
+					case 3 -> "🥉";
+					default -> rank + "위";
+				};
+				sb.append(String.format("  %s %s: %d점\n", medal, entry.getKey(), entry.getValue()));
+				rank++;
+			}
+		} else {
+			sb.append("  점수 없음");
+		}
+
+		logger.info("Game finished: roomId={}, reason={}", room.getRoomId(), reason);
+
+		return CommandResult.success(MessageType.GAME_END, sb.toString(), room.getScores());
+	}
+
+	/**
+	 * 랜덤 단어 추출
+	 */
+	private List<Word> getRandomWords(String level, int count) {
+		PaginatedResult<Word> result = wordRepository.findByLevelWithPagination(level, 50, null);
+		List<Word> words = new ArrayList<>(result.items());
+		Collections.shuffle(words);
+		return words.stream().limit(count).collect(Collectors.toList());
+	}
+
+	/**
+	 * 정답 체크 로직
+	 */
+	private boolean isCorrectAnswer(String input, String answer) {
+		if (input == null || answer == null) return false;
+
+		String normalizedInput = input.trim().toLowerCase().replace(" ", "");
+		String normalizedAnswer = answer.trim().toLowerCase().replace(" ", "");
+
+		return normalizedInput.equals(normalizedAnswer);
+	}
+
+	/**
+	 * 점수 계산
+	 */
+	private int calculateScore(ChatRoom room, long elapsedTimeMs, String userId) {
+		int baseScore = 10;
+
+		// 시간 보너스 (빨리 맞출수록 높은 점수)
+		int elapsedSeconds = (int) (elapsedTimeMs / 1000);
+		int timeLimit = room.getRoundTimeLimit() != null ? room.getRoundTimeLimit() : DEFAULT_ROUND_TIME_LIMIT;
+		int timeBonus = Math.max(0, (timeLimit - elapsedSeconds) / 2);
+
+		// 연속 정답 보너스 (추후 구현)
+		int streakBonus = 0;
+
+		return baseScore + timeBonus + streakBonus;
+	}
+
+	/**
+	 * 라운드 기록 업데이트
+	 */
+	private void updateRoundRecord(String roomId, Integer roundNumber, String userId, long elapsedTime, int score) {
+		gameRoundRepository.findByRoomIdAndRound(roomId, roundNumber)
+				.ifPresent(round -> {
+					if (round.getCorrectGuessers() == null) {
+						round.setCorrectGuessers(new ArrayList<>());
+					}
+					round.getCorrectGuessers().add(userId);
+
+					if (round.getGuessTimes() == null) {
+						round.setGuessTimes(new HashMap<>());
+					}
+					round.getGuessTimes().put(userId, elapsedTime);
+
+					if (round.getRoundScores() == null) {
+						round.setRoundScores(new HashMap<>());
+					}
+					round.getRoundScores().put(userId, score);
+
+					gameRoundRepository.save(round);
+				});
+	}
+
+	// ========== Result DTOs ==========
+
+	public record GameStartResult(
+			boolean success,
+			String error,
+			ChatRoom room,
+			Word firstWord,
+			List<String> drawerOrder
+	) {
+		public static GameStartResult success(ChatRoom room, Word word, List<String> order) {
+			return new GameStartResult(true, null, room, word, order);
+		}
+
+		public static GameStartResult error(String message) {
+			return new GameStartResult(false, message, null, null, null);
+		}
+	}
+
+	public record AnswerCheckResult(
+			boolean correct,
+			boolean drawer,
+			boolean alreadyGuessed,
+			boolean gameNotActive,
+			boolean allCorrect,
+			int score,
+			long elapsedTime,
+			Map<String, Integer> scores
+	) {
+		public static AnswerCheckResult correctAnswer(int score, long elapsed, boolean allCorrect, Map<String, Integer> scores) {
+			return new AnswerCheckResult(true, false, false, false, allCorrect, score, elapsed, scores);
+		}
+
+		public static AnswerCheckResult wrongAnswer() {
+			return new AnswerCheckResult(false, false, false, false, false, 0, 0, null);
+		}
+
+		public static AnswerCheckResult drawerCannotGuess() {
+			return new AnswerCheckResult(false, true, false, false, false, 0, 0, null);
+		}
+
+		public static AnswerCheckResult alreadyGuessedCorrect() {
+			return new AnswerCheckResult(false, false, true, false, false, 0, 0, null);
+		}
+
+		public static AnswerCheckResult gameNotPlaying() {
+			return new AnswerCheckResult(false, false, false, true, false, 0, 0, null);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
캐치마인드 게임의 상태 관리 및 라운드 진행 로직 구현

## 변경사항
- `GameStatus` enum 생성 (NONE, WAITING, PLAYING, ROUND_END, FINISHED)
- `GameRound` 모델 및 `GameRoundRepository` 생성
- `GameService` 구현:
  - 게임 시작/종료 로직
  - 라운드 진행 및 정답 체크
  - 점수 계산 (기본점수 + 시간보너스)
  - 힌트 제공
- `CommandService`에 `GameService` 연동

## 게임 플로우
1. `/start` → 게임 시작, 출제 순서 랜덤 생성, 첫 라운드 시작
2. 출제자가 그림을 그리고, 나머지가 정답 입력
3. 정답 맞추면 점수 획득 (빨리 맞출수록 높은 점수)
4. 전원 정답 or 시간 초과 or `/skip` → 다음 라운드
5. 총 5라운드 후 게임 종료, 최종 순위 발표

## 관련 이슈
- closes #223
- refs #234, #235, #236

## Test plan
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] `/start` 명령어로 게임 시작 테스트
- [ ] `/skip` 명령어로 라운드 스킵 테스트
- [ ] `/hint` 명령어로 힌트 제공 테스트