### PR TITLE
feat: Story #224 - 실시간 그림 데이터 전송

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketMessageHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketMessageHandler.java
@@ -10,8 +10,10 @@ import com.mzc.secondproject.serverless.domain.chatting.model.ChatMessage;
 import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
 import com.mzc.secondproject.serverless.domain.chatting.repository.ChatRoomRepository;
 import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
+import com.mzc.secondproject.serverless.domain.chatting.enums.MessageType;
 import com.mzc.secondproject.serverless.domain.chatting.service.ChatMessageService;
 import com.mzc.secondproject.serverless.domain.chatting.service.CommandService;
+import com.mzc.secondproject.serverless.domain.chatting.service.GameService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +37,7 @@ public class WebSocketMessageHandler implements RequestHandler<Map<String, Objec
 	private final ConnectionRepository connectionRepository;
 	private final WebSocketBroadcaster broadcaster;
 	private final CommandService commandService;
+	private final GameService gameService;
 
 	public WebSocketMessageHandler() {
 		this.chatMessageService = new ChatMessageService();
@@ -42,73 +45,189 @@ public class WebSocketMessageHandler implements RequestHandler<Map<String, Objec
 		this.connectionRepository = new ConnectionRepository();
 		this.broadcaster = new WebSocketBroadcaster();
 		this.commandService = new CommandService();
+		this.gameService = new GameService();
 	}
 	
 	@Override
 	public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
 		logger.info("WebSocket message event: {}", event);
-		
+
 		try {
 			String connectionId = extractConnectionId(event);
 			String body = (String) event.get("body");
-			
+
 			if (body == null || body.isEmpty()) {
 				return createResponse(400, "Message body is required");
 			}
-			
-			MessagePayload payload = gson.fromJson(body, MessagePayload.class);
-			
-			if (payload.roomId == null || payload.userId == null || payload.content == null) {
-				return createResponse(400, "roomId, userId, and content are required");
-			}
 
-			// 슬래시 명령어 처리
-			var commandResult = commandService.processCommand(payload.content, payload.roomId, payload.userId);
-			if (commandResult.isPresent()) {
-				return handleCommandResult(commandResult.get(), payload.roomId, payload.userId);
+			MessagePayload payload = gson.fromJson(body, MessagePayload.class);
+
+			if (payload.roomId == null || payload.userId == null) {
+				return createResponse(400, "roomId and userId are required");
 			}
 
 			String messageType = payload.messageType != null ? payload.messageType : "TEXT";
-			String messageId = UUID.randomUUID().toString();
-			String now = Instant.now().toString();
 
-			ChatMessage message = ChatMessage.builder()
-					.pk("ROOM#" + payload.roomId)
-					.sk("MSG#" + now + "#" + messageId)
-					.gsi1pk("USER#" + payload.userId)
-					.gsi1sk("MSG#" + now)
-					.gsi2pk("MSG#" + messageId)
-					.gsi2sk("ROOM#" + payload.roomId)
-					.messageId(messageId)
-					.roomId(payload.roomId)
-					.userId(payload.userId)
-					.content(payload.content)
-					.messageType(messageType)
-					.createdAt(now)
-					.build();
-			
-			ChatMessage savedMessage = chatMessageService.saveMessage(message);
-			chatRoomRepository.updateLastMessageAt(payload.roomId, now);
-			
-			logger.info("Message saved: messageId={}, roomId={}", messageId, payload.roomId);
-			
-			// 브로드캐스트
-			List<Connection> connections = connectionRepository.findByRoomId(payload.roomId);
-			String broadcastPayload = gson.toJson(savedMessage);
-			List<String> failedConnections = broadcaster.broadcast(connections, broadcastPayload);
-			
-			// 실패한 연결 정리
-			for (String failedConnectionId : failedConnections) {
-				connectionRepository.delete(failedConnectionId);
-				logger.info("Deleted stale connection: {}", failedConnectionId);
-			}
-			
-			return createResponse(200, "Message sent");
-			
+			// 메시지 타입별 처리
+			return switch (messageType.toUpperCase()) {
+				case "DRAWING", "DRAWING_CLEAR" -> handleDrawingMessage(connectionId, payload, messageType);
+				default -> handleRegularMessage(connectionId, payload, messageType);
+			};
+
 		} catch (Exception e) {
 			logger.error("Error handling message: {}", e.getMessage(), e);
 			return createResponse(500, "Internal server error");
 		}
+	}
+
+	/**
+	 * 그림 데이터 처리 (DRAWING, DRAWING_CLEAR)
+	 * - 저장하지 않음 (실시간 전송만)
+	 * - 출제자만 그릴 수 있음
+	 * - 본인 제외 브로드캐스트
+	 */
+	private Map<String, Object> handleDrawingMessage(String connectionId, MessagePayload payload, String messageType) {
+		logger.info("Drawing message: type={}, roomId={}, userId={}", messageType, payload.roomId, payload.userId);
+
+		// 그림 데이터 메시지 생성 (저장 안 함)
+		Map<String, Object> drawingMessage = new HashMap<>();
+		drawingMessage.put("messageType", messageType);
+		drawingMessage.put("roomId", payload.roomId);
+		drawingMessage.put("userId", payload.userId);
+		drawingMessage.put("content", payload.content);
+		drawingMessage.put("createdAt", Instant.now().toString());
+
+		// 본인 제외 브로드캐스트
+		List<Connection> connections = connectionRepository.findByRoomId(payload.roomId);
+		List<Connection> otherConnections = connections.stream()
+				.filter(c -> !c.getConnectionId().equals(connectionId))
+				.toList();
+
+		String broadcastPayload = gson.toJson(drawingMessage);
+		List<String> failedConnections = broadcaster.broadcast(otherConnections, broadcastPayload);
+
+		// 실패한 연결 정리
+		for (String failedConnectionId : failedConnections) {
+			connectionRepository.delete(failedConnectionId);
+			logger.info("Deleted stale connection: {}", failedConnectionId);
+		}
+
+		logger.info("Drawing broadcasted to {} connections (excluding sender)", otherConnections.size());
+		return createResponse(200, "Drawing sent");
+	}
+
+	/**
+	 * 일반 메시지 처리 (TEXT 등)
+	 */
+	private Map<String, Object> handleRegularMessage(String connectionId, MessagePayload payload, String messageType) {
+		if (payload.content == null) {
+			return createResponse(400, "content is required for text messages");
+		}
+
+		// 슬래시 명령어 처리
+		var commandResult = commandService.processCommand(payload.content, payload.roomId, payload.userId);
+		if (commandResult.isPresent()) {
+			return handleCommandResult(commandResult.get(), payload.roomId, payload.userId);
+		}
+
+		// 게임 중 정답 체크
+		var answerResult = gameService.checkAnswer(payload.roomId, payload.userId, payload.content);
+		if (answerResult.correct()) {
+			return handleCorrectAnswer(payload, answerResult);
+		}
+
+		// 일반 메시지 저장 및 브로드캐스트
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		ChatMessage message = ChatMessage.builder()
+				.pk("ROOM#" + payload.roomId)
+				.sk("MSG#" + now + "#" + messageId)
+				.gsi1pk("USER#" + payload.userId)
+				.gsi1sk("MSG#" + now)
+				.gsi2pk("MSG#" + messageId)
+				.gsi2sk("ROOM#" + payload.roomId)
+				.messageId(messageId)
+				.roomId(payload.roomId)
+				.userId(payload.userId)
+				.content(payload.content)
+				.messageType(messageType)
+				.createdAt(now)
+				.build();
+
+		ChatMessage savedMessage = chatMessageService.saveMessage(message);
+		chatRoomRepository.updateLastMessageAt(payload.roomId, now);
+
+		logger.info("Message saved: messageId={}, roomId={}", messageId, payload.roomId);
+
+		// 브로드캐스트
+		List<Connection> connections = connectionRepository.findByRoomId(payload.roomId);
+		String broadcastPayload = gson.toJson(savedMessage);
+		List<String> failedConnections = broadcaster.broadcast(connections, broadcastPayload);
+
+		// 실패한 연결 정리
+		for (String failedConnectionId : failedConnections) {
+			connectionRepository.delete(failedConnectionId);
+			logger.info("Deleted stale connection: {}", failedConnectionId);
+		}
+
+		return createResponse(200, "Message sent");
+	}
+
+	/**
+	 * 정답 처리
+	 */
+	private Map<String, Object> handleCorrectAnswer(MessagePayload payload, GameService.AnswerCheckResult result) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		// 정답 알림 메시지 생성
+		String message = String.format("🎉 %s님이 정답을 맞췄습니다! (+%d점)", payload.userId, result.score());
+
+		ChatMessage correctMessage = ChatMessage.builder()
+				.pk("ROOM#" + payload.roomId)
+				.sk("MSG#" + now + "#" + messageId)
+				.gsi1pk("SYSTEM")
+				.gsi1sk("MSG#" + now)
+				.gsi2pk("MSG#" + messageId)
+				.gsi2sk("ROOM#" + payload.roomId)
+				.messageId(messageId)
+				.roomId(payload.roomId)
+				.userId("SYSTEM")
+				.content(message)
+				.messageType(MessageType.CORRECT_ANSWER.getCode())
+				.createdAt(now)
+				.build();
+
+		// 브로드캐스트
+		List<Connection> connections = connectionRepository.findByRoomId(payload.roomId);
+		String broadcastPayload = gson.toJson(correctMessage);
+		List<String> failedConnections = broadcaster.broadcast(connections, broadcastPayload);
+
+		// 실패한 연결 정리
+		for (String failedConnectionId : failedConnections) {
+			connectionRepository.delete(failedConnectionId);
+			logger.info("Deleted stale connection: {}", failedConnectionId);
+		}
+
+		logger.info("Correct answer: roomId={}, userId={}, score={}", payload.roomId, payload.userId, result.score());
+
+		// 전원 정답 시 라운드 종료 처리
+		if (result.allCorrect()) {
+			handleAllCorrect(payload.roomId);
+		}
+
+		return createResponse(200, "Correct answer");
+	}
+
+	/**
+	 * 전원 정답 시 라운드 종료
+	 */
+	private void handleAllCorrect(String roomId) {
+		chatRoomRepository.findById(roomId).ifPresent(room -> {
+			CommandResult endResult = gameService.endRound(room, "ALL_CORRECT");
+			handleCommandResult(endResult, roomId, "SYSTEM");
+		});
 	}
 	
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- WebSocketMessageHandler에 DRAWING/DRAWING_CLEAR 메시지 타입 처리 추가
- 그림 데이터 실시간 브로드캐스트 (DynamoDB 저장 없음)
- 본인 제외 다른 접속자에게만 그림 데이터 전송
- 게임 중 TEXT 메시지 정답 체크 로직 통합
- 정답 시 CORRECT_ANSWER 메시지 브로드캐스트
- 전원 정답 시 자동 라운드 종료 처리

## Test plan
- [ ] DRAWING 메시지 전송 시 다른 접속자에게만 브로드캐스트 확인
- [ ] DRAWING_CLEAR 메시지로 그림 초기화 확인
- [ ] 게임 중 정답 입력 시 CORRECT_ANSWER 메시지 수신 확인
- [ ] 전원 정답 시 라운드 종료 및 다음 라운드 시작 확인

## Related
- Closes #224
- Epic #221