### PR TITLE
feat: Story #226 - 게임 REST API 구현

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/response/GameStatusResponse.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/response/GameStatusResponse.java
@@ -1,0 +1,37 @@
+package com.mzc.secondproject.serverless.domain.chatting.dto.response;
+
+import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 게임 상태 응답 DTO
+ */
+public record GameStatusResponse(
+		String gameStatus,
+		Integer currentRound,
+		Integer totalRounds,
+		String currentDrawerId,
+		Long roundStartTime,
+		Integer roundTimeLimit,
+		List<String> drawerOrder,
+		Map<String, Integer> scores,
+		Boolean hintUsed,
+		List<String> correctGuessers
+) {
+	public static GameStatusResponse from(ChatRoom room, List<String> drawerOrder) {
+		return new GameStatusResponse(
+				room.getGameStatus(),
+				room.getCurrentRound(),
+				room.getTotalRounds(),
+				room.getCurrentDrawerId(),
+				room.getRoundStartTime(),
+				room.getRoundTimeLimit(),
+				drawerOrder != null ? drawerOrder : room.getDrawerOrder(),
+				room.getScores(),
+				room.getHintUsed(),
+				room.getCorrectGuessers()
+		);
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/response/ScoreboardResponse.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/response/ScoreboardResponse.java
@@ -1,0 +1,51 @@
+package com.mzc.secondproject.serverless.domain.chatting.dto.response;
+
+import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 점수판 응답 DTO
+ */
+public record ScoreboardResponse(
+		Map<String, Integer> scores,
+		List<RankEntry> ranking,
+		String gameStatus,
+		Integer currentRound,
+		Integer totalRounds
+) {
+	public record RankEntry(
+			int rank,
+			String userId,
+			int score
+	) {}
+
+	public static ScoreboardResponse from(ChatRoom room) {
+		Map<String, Integer> scores = room.getScores();
+		List<RankEntry> ranking = buildRanking(scores);
+
+		return new ScoreboardResponse(
+				scores,
+				ranking,
+				room.getGameStatus(),
+				room.getCurrentRound(),
+				room.getTotalRounds()
+		);
+	}
+
+	private static List<RankEntry> buildRanking(Map<String, Integer> scores) {
+		if (scores == null || scores.isEmpty()) {
+			return List.of();
+		}
+
+		List<Map.Entry<String, Integer>> sorted = scores.entrySet().stream()
+				.sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+				.toList();
+
+		return java.util.stream.IntStream.range(0, sorted.size())
+				.mapToObj(i -> new RankEntry(i + 1, sorted.get(i).getKey(), sorted.get(i).getValue()))
+				.toList();
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
@@ -33,6 +33,13 @@ public enum ChattingErrorCode implements DomainErrorCode {
 	// 연결 관련 에러
 	CONNECTION_FAILED("CONN_001", "연결에 실패했습니다", 500),
 	CONNECTION_TIMEOUT("CONN_002", "연결 시간이 초과되었습니다", 408),
+
+	// 게임 관련 에러
+	GAME_START_FAILED("GAME_001", "게임 시작에 실패했습니다", 400),
+	GAME_STOP_FAILED("GAME_002", "게임 중단에 실패했습니다", 400),
+	GAME_NOT_IN_PROGRESS("GAME_003", "진행 중인 게임이 없습니다", 400),
+	GAME_ALREADY_IN_PROGRESS("GAME_004", "이미 게임이 진행 중입니다", 409),
+	NOT_GAME_STARTER("GAME_005", "게임 시작자만 중단할 수 있습니다", 403),
 	;
 	
 	private static final String DOMAIN = "CHATTING";

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameHandler.java
@@ -1,0 +1,194 @@
+package com.mzc.secondproject.serverless.domain.chatting.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.mzc.secondproject.serverless.common.router.HandlerRouter;
+import com.mzc.secondproject.serverless.common.router.Route;
+import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
+import com.mzc.secondproject.serverless.common.util.WebSocketBroadcaster;
+import com.mzc.secondproject.serverless.domain.chatting.dto.response.CommandResult;
+import com.mzc.secondproject.serverless.domain.chatting.dto.response.GameStatusResponse;
+import com.mzc.secondproject.serverless.domain.chatting.dto.response.ScoreboardResponse;
+import com.mzc.secondproject.serverless.domain.chatting.enums.GameStatus;
+import com.mzc.secondproject.serverless.domain.chatting.enums.MessageType;
+import com.mzc.secondproject.serverless.domain.chatting.exception.ChattingErrorCode;
+import com.mzc.secondproject.serverless.domain.chatting.model.ChatMessage;
+import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
+import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ChatRoomRepository;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
+import com.mzc.secondproject.serverless.domain.chatting.service.GameService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * 게임 REST API 핸들러
+ */
+public class GameHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+	private static final Logger logger = LoggerFactory.getLogger(GameHandler.class);
+
+	private final GameService gameService;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ConnectionRepository connectionRepository;
+	private final WebSocketBroadcaster broadcaster;
+	private final HandlerRouter router;
+
+	public GameHandler() {
+		this.gameService = new GameService();
+		this.chatRoomRepository = new ChatRoomRepository();
+		this.connectionRepository = new ConnectionRepository();
+		this.broadcaster = new WebSocketBroadcaster();
+		this.router = initRouter();
+	}
+
+	private HandlerRouter initRouter() {
+		return new HandlerRouter().addRoutes(
+				Route.postAuth("/rooms/{roomId}/game/start", this::startGame),
+				Route.postAuth("/rooms/{roomId}/game/stop", this::stopGame),
+				Route.getAuth("/rooms/{roomId}/game/status", this::getGameStatus),
+				Route.getAuth("/rooms/{roomId}/game/scores", this::getScores)
+		);
+	}
+
+	@Override
+	public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request, Context context) {
+		logger.info("Received request: {} {}", request.getHttpMethod(), request.getPath());
+		return router.route(request);
+	}
+
+	/**
+	 * POST /rooms/{roomId}/game/start - 게임 시작
+	 */
+	private APIGatewayProxyResponseEvent startGame(APIGatewayProxyRequestEvent request, String userId) {
+		String roomId = request.getPathParameters().get("roomId");
+
+		GameService.GameStartResult result = gameService.startGame(roomId, userId);
+
+		if (!result.success()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_START_FAILED, result.error());
+		}
+
+		// WebSocket으로 게임 시작 알림 브로드캐스트
+		broadcastGameStart(roomId, result);
+
+		GameStatusResponse response = GameStatusResponse.from(result.room(), result.drawerOrder());
+		return ResponseGenerator.ok("Game started", response);
+	}
+
+	/**
+	 * POST /rooms/{roomId}/game/stop - 게임 중단
+	 */
+	private APIGatewayProxyResponseEvent stopGame(APIGatewayProxyRequestEvent request, String userId) {
+		String roomId = request.getPathParameters().get("roomId");
+
+		CommandResult result = gameService.stopGame(roomId, userId);
+
+		if (!result.success()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_STOP_FAILED, result.message());
+		}
+
+		// WebSocket으로 게임 종료 알림 브로드캐스트
+		broadcastSystemMessage(roomId, result.message(), MessageType.GAME_END);
+
+		return ResponseGenerator.ok("Game stopped", Map.of("message", result.message()));
+	}
+
+	/**
+	 * GET /rooms/{roomId}/game/status - 게임 상태 조회
+	 */
+	private APIGatewayProxyResponseEvent getGameStatus(APIGatewayProxyRequestEvent request, String userId) {
+		String roomId = request.getPathParameters().get("roomId");
+
+		Optional<ChatRoom> optRoom = chatRoomRepository.findById(roomId);
+		if (optRoom.isEmpty()) {
+			return ResponseGenerator.fail(ChattingErrorCode.ROOM_NOT_FOUND);
+		}
+
+		ChatRoom room = optRoom.get();
+		GameStatusResponse response = GameStatusResponse.from(room, room.getDrawerOrder());
+
+		return ResponseGenerator.ok("Game status retrieved", response);
+	}
+
+	/**
+	 * GET /rooms/{roomId}/game/scores - 점수 조회
+	 */
+	private APIGatewayProxyResponseEvent getScores(APIGatewayProxyRequestEvent request, String userId) {
+		String roomId = request.getPathParameters().get("roomId");
+
+		Optional<ChatRoom> optRoom = chatRoomRepository.findById(roomId);
+		if (optRoom.isEmpty()) {
+			return ResponseGenerator.fail(ChattingErrorCode.ROOM_NOT_FOUND);
+		}
+
+		ChatRoom room = optRoom.get();
+		ScoreboardResponse response = ScoreboardResponse.from(room);
+
+		return ResponseGenerator.ok("Scores retrieved", response);
+	}
+
+	/**
+	 * 게임 시작 브로드캐스트
+	 */
+	private void broadcastGameStart(String roomId, GameService.GameStartResult result) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		String message = String.format("""
+				🎮 게임 시작!
+				총 %d 라운드
+
+				라운드 1 시작!
+				출제자: %s
+				""",
+				result.room().getTotalRounds(),
+				result.room().getCurrentDrawerId());
+
+		Map<String, Object> gameStartMessage = new HashMap<>();
+		gameStartMessage.put("messageId", messageId);
+		gameStartMessage.put("roomId", roomId);
+		gameStartMessage.put("userId", "SYSTEM");
+		gameStartMessage.put("content", message);
+		gameStartMessage.put("messageType", MessageType.GAME_START.getCode());
+		gameStartMessage.put("createdAt", now);
+		gameStartMessage.put("gameStatus", result.room().getGameStatus());
+		gameStartMessage.put("currentRound", result.room().getCurrentRound());
+		gameStartMessage.put("totalRounds", result.room().getTotalRounds());
+		gameStartMessage.put("currentDrawerId", result.room().getCurrentDrawerId());
+		gameStartMessage.put("drawerOrder", result.drawerOrder());
+
+		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		String broadcastPayload = ResponseGenerator.gson().toJson(gameStartMessage);
+		broadcaster.broadcast(connections, broadcastPayload);
+
+		logger.info("Game start broadcasted: roomId={}", roomId);
+	}
+
+	/**
+	 * 시스템 메시지 브로드캐스트
+	 */
+	private void broadcastSystemMessage(String roomId, String message, MessageType messageType) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		Map<String, Object> systemMessage = new HashMap<>();
+		systemMessage.put("messageId", messageId);
+		systemMessage.put("roomId", roomId);
+		systemMessage.put("userId", "SYSTEM");
+		systemMessage.put("content", message);
+		systemMessage.put("messageType", messageType.getCode());
+		systemMessage.put("createdAt", now);
+
+		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		String broadcastPayload = ResponseGenerator.gson().toJson(systemMessage);
+		broadcaster.broadcast(connections, broadcastPayload);
+
+		logger.info("System message broadcasted: roomId={}, type={}", roomId, messageType);
+	}
+}

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -330,6 +330,57 @@ Resources:
             Auth:
               Authorizer: CognitoAuthorizer
 
+  GameFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: group2-englishstudy-game-handler
+      CodeUri: .
+      Handler: com.mzc.secondproject.serverless.domain.chatting.handler.GameHandler::handleRequest
+      Description: Handle catch-mind game operations
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref ChatTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - execute-api:ManageConnections
+              Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ChatWebSocketApi}/*"
+      Events:
+        StartGame:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /chat/rooms/{roomId}/game/start
+            Method: POST
+            Auth:
+              Authorizer: CognitoAuthorizer
+        StopGame:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /chat/rooms/{roomId}/game/stop
+            Method: POST
+            Auth:
+              Authorizer: CognitoAuthorizer
+        GetGameStatus:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /chat/rooms/{roomId}/game/status
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+        GetScores:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MainApi
+            Path: /chat/rooms/{roomId}/game/scores
+            Method: GET
+            Auth:
+              Authorizer: CognitoAuthorizer
+
   ChatMessageFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
## Summary
- GameHandler REST API 핸들러 신규 생성
- 4개 엔드포인트 구현:
  - `POST /chat/rooms/{roomId}/game/start` - 게임 시작
  - `POST /chat/rooms/{roomId}/game/stop` - 게임 중단  
  - `GET /chat/rooms/{roomId}/game/status` - 게임 상태 조회
  - `GET /chat/rooms/{roomId}/game/scores` - 점수 조회
- GameStatusResponse, ScoreboardResponse DTO 추가
- ChattingErrorCode에 게임 관련 에러 코드 추가
- template.yaml에 GameFunction Lambda 구성 추가

## Test plan
- [ ] POST /game/start API로 게임 시작 확인
- [ ] POST /game/stop API로 게임 중단 확인
- [ ] GET /game/status API로 게임 상태 조회 확인
- [ ] GET /game/scores API로 점수 조회 확인
- [ ] Cognito 인증 적용 확인

## Related
- Closes #226
- Task #242
- Epic #221