### PR TITLE
feat: Story #227 - 게임 통계/뱃지 연동

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/enums/BadgeType.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/enums/BadgeType.java
@@ -24,6 +24,12 @@ public enum BadgeType {
 	// 정확도
 	ACCURACY_90("정확도 달인", "전체 정확도 90%를 달성했습니다", "accuracy_90.png", "ACCURACY", 90),
 	
+	// 게임 관련
+	GAME_FIRST_PLAY("첫 게임", "첫 게임에 참여했습니다", "game_first.png", "GAMES_PLAYED", 1),
+	GAME_10_WINS("게임 10승", "게임에서 10번 1등을 했습니다", "game_10_wins.png", "GAMES_WON", 10),
+	QUICK_GUESSER("번개 정답", "5초 내에 정답을 맞췄습니다", "quick_guesser.png", "QUICK_GUESSES", 1),
+	PERFECT_DRAWER("완벽한 출제자", "출제 시 전원이 정답을 맞췄습니다", "perfect_drawer.png", "PERFECT_DRAWS", 1),
+
 	// 특별
 	MASTER("학습 마스터", "모든 업적을 달성했습니다", "master.png", "ALL_BADGES", 1);
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/service/BadgeService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/service/BadgeService.java
@@ -131,7 +131,7 @@ public class BadgeService {
 	
 	private boolean checkBadgeCondition(BadgeType type, UserStats stats) {
 		if (stats == null) return false;
-		
+
 		return switch (type.getCategory()) {
 			case "FIRST_STUDY" -> stats.getTestsCompleted() != null && stats.getTestsCompleted() >= 1;
 			case "STREAK" -> stats.getCurrentStreak() != null && stats.getCurrentStreak() >= type.getThreshold();
@@ -148,6 +148,14 @@ public class BadgeService {
 				double accuracy = (stats.getCorrectAnswers() * 100.0) / stats.getQuestionsAnswered();
 				yield accuracy >= type.getThreshold();
 			}
+			case "GAMES_PLAYED" ->
+					stats.getGamesPlayed() != null && stats.getGamesPlayed() >= type.getThreshold();
+			case "GAMES_WON" ->
+					stats.getGamesWon() != null && stats.getGamesWon() >= type.getThreshold();
+			case "QUICK_GUESSES" ->
+					stats.getQuickGuesses() != null && stats.getQuickGuesses() >= type.getThreshold();
+			case "PERFECT_DRAWS" ->
+					stats.getPerfectDraws() != null && stats.getPerfectDraws() >= type.getThreshold();
 			case "ALL_BADGES" -> false; // 별도 로직 필요
 			default -> false;
 		};
@@ -155,7 +163,7 @@ public class BadgeService {
 	
 	private int calculateProgress(BadgeType type, UserStats stats) {
 		if (stats == null) return 0;
-		
+
 		return switch (type.getCategory()) {
 			case "FIRST_STUDY" -> stats.getTestsCompleted() != null && stats.getTestsCompleted() >= 1 ? 1 : 0;
 			case "STREAK" -> stats.getCurrentStreak() != null ? stats.getCurrentStreak() : 0;
@@ -166,6 +174,10 @@ public class BadgeService {
 				if (stats.getQuestionsAnswered() == null || stats.getQuestionsAnswered() == 0) yield 0;
 				yield (int) ((stats.getCorrectAnswers() * 100.0) / stats.getQuestionsAnswered());
 			}
+			case "GAMES_PLAYED" -> stats.getGamesPlayed() != null ? stats.getGamesPlayed() : 0;
+			case "GAMES_WON" -> stats.getGamesWon() != null ? stats.getGamesWon() : 0;
+			case "QUICK_GUESSES" -> stats.getQuickGuesses() != null ? stats.getQuickGuesses() : 0;
+			case "PERFECT_DRAWS" -> stats.getPerfectDraws() != null ? stats.getPerfectDraws() : 0;
 			default -> 0;
 		};
 	}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
@@ -32,12 +32,14 @@ public class GameService {
 	private final ConnectionRepository connectionRepository;
 	private final GameRoundRepository gameRoundRepository;
 	private final WordRepository wordRepository;
+	private final GameStatsService gameStatsService;
 
 	public GameService() {
 		this.chatRoomRepository = new ChatRoomRepository();
 		this.connectionRepository = new ConnectionRepository();
 		this.gameRoundRepository = new GameRoundRepository();
 		this.wordRepository = new WordRepository();
+		this.gameStatsService = new GameStatsService();
 	}
 
 	/**
@@ -354,6 +356,14 @@ public class GameService {
 	private CommandResult finishGame(ChatRoom room, String reason) {
 		room.setGameStatus(GameStatus.FINISHED.name());
 		chatRoomRepository.save(room);
+
+		// 게임 통계 업데이트 및 뱃지 체크
+		try {
+			var newBadges = gameStatsService.updateGameStats(room);
+			logger.info("Game stats updated: roomId={}, newBadges={}", room.getRoomId(), newBadges.size());
+		} catch (Exception e) {
+			logger.error("Failed to update game stats: roomId={}, error={}", room.getRoomId(), e.getMessage());
+		}
 
 		// 최종 점수 정렬
 		StringBuilder sb = new StringBuilder("🎮 게임 종료!\n\n📊 최종 순위:\n");

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameStatsService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameStatsService.java
@@ -1,0 +1,147 @@
+package com.mzc.secondproject.serverless.domain.chatting.service;
+
+import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
+import com.mzc.secondproject.serverless.domain.badge.service.BadgeService;
+import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
+import com.mzc.secondproject.serverless.domain.chatting.model.GameRound;
+import com.mzc.secondproject.serverless.domain.chatting.repository.GameRoundRepository;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * 게임 통계 및 뱃지 연동 서비스
+ */
+public class GameStatsService {
+
+	private static final Logger logger = LoggerFactory.getLogger(GameStatsService.class);
+	private static final long QUICK_GUESS_THRESHOLD_MS = 5000; // 5초
+
+	private final UserStatsRepository userStatsRepository;
+	private final GameRoundRepository gameRoundRepository;
+	private final BadgeService badgeService;
+
+	public GameStatsService() {
+		this.userStatsRepository = new UserStatsRepository();
+		this.gameRoundRepository = new GameRoundRepository();
+		this.badgeService = new BadgeService();
+	}
+
+	/**
+	 * 게임 종료 시 모든 참가자 통계 업데이트
+	 */
+	public Map<String, List<UserBadge>> updateGameStats(ChatRoom room) {
+		Map<String, List<UserBadge>> newBadges = new HashMap<>();
+		String roomId = room.getRoomId();
+
+		// 모든 라운드 조회
+		List<GameRound> rounds = gameRoundRepository.findByRoomId(roomId);
+
+		// 참가자별 통계 수집
+		Map<String, Integer> scores = room.getScores() != null ? room.getScores() : Map.of();
+		Set<String> participants = new HashSet<>(scores.keySet());
+		if (room.getDrawerOrder() != null) {
+			participants.addAll(room.getDrawerOrder());
+		}
+
+		// 1등 찾기
+		String winner = findWinner(scores);
+
+		// 각 참가자 통계 업데이트
+		for (String userId : participants) {
+			List<UserBadge> badges = updateUserGameStats(userId, scores.getOrDefault(userId, 0),
+					userId.equals(winner), rounds);
+			if (!badges.isEmpty()) {
+				newBadges.put(userId, badges);
+			}
+		}
+
+		logger.info("Game stats updated: roomId={}, participants={}, winner={}",
+				roomId, participants.size(), winner);
+
+		return newBadges;
+	}
+
+	/**
+	 * 개별 사용자 게임 통계 업데이트
+	 */
+	private List<UserBadge> updateUserGameStats(String userId, int score, boolean isWinner,
+			List<GameRound> rounds) {
+		// 라운드별 통계 수집
+		int correctGuesses = 0;
+		int quickGuesses = 0;
+		int perfectDraws = 0;
+
+		for (GameRound round : rounds) {
+			// 정답 횟수
+			if (round.getCorrectGuessers() != null && round.getCorrectGuessers().contains(userId)) {
+				correctGuesses++;
+
+				// 빠른 정답 체크 (5초 이내)
+				if (round.getGuessTimes() != null) {
+					Long guessTime = round.getGuessTimes().get(userId);
+					if (guessTime != null && guessTime <= QUICK_GUESS_THRESHOLD_MS) {
+						quickGuesses++;
+					}
+				}
+			}
+
+			// 완벽한 출제자 체크
+			if (userId.equals(round.getDrawerId())) {
+				// 출제자일 때 전원 정답인지 확인
+				if (round.getEndReason() != null && "ALL_CORRECT".equals(round.getEndReason())) {
+					perfectDraws++;
+				}
+			}
+		}
+
+		// Atomic 업데이트
+		userStatsRepository.incrementGameStats(
+				userId,
+				1, // gamesPlayed
+				isWinner ? 1 : 0, // gamesWon
+				correctGuesses,
+				score,
+				quickGuesses,
+				perfectDraws
+		);
+
+		// 뱃지 체크를 위해 업데이트된 통계 조회
+		UserStats stats = userStatsRepository.findTotalStats(userId).orElse(null);
+		List<UserBadge> newBadges = badgeService.checkAndAwardBadges(userId, stats);
+
+		logger.info("User game stats updated: userId={}, correctGuesses={}, newBadges={}",
+				userId, correctGuesses, newBadges.size());
+
+		return newBadges;
+	}
+
+	/**
+	 * 정답 시 즉시 통계 업데이트 (빠른 정답 뱃지용)
+	 */
+	public List<UserBadge> updateOnCorrectAnswer(String userId, long elapsedTimeMs) {
+		if (elapsedTimeMs > QUICK_GUESS_THRESHOLD_MS) {
+			return List.of();
+		}
+
+		// 빠른 정답만 업데이트
+		userStatsRepository.incrementGameStats(userId, 0, 0, 0, 0, 1, 0);
+
+		UserStats stats = userStatsRepository.findTotalStats(userId).orElse(null);
+		return badgeService.checkAndAwardBadges(userId, stats);
+	}
+
+	private String findWinner(Map<String, Integer> scores) {
+		if (scores == null || scores.isEmpty()) {
+			return null;
+		}
+		return scores.entrySet().stream()
+				.max(Map.Entry.comparingByValue())
+				.map(Map.Entry::getKey)
+				.orElse(null);
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/model/UserStats.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/model/UserStats.java
@@ -48,7 +48,15 @@ public class UserStats {
 	private Integer currentStreak;      // 현재 연속 학습일
 	private Integer longestStreak;      // 최장 연속 학습일
 	private String lastStudyDate;       // 마지막 학습일
-	
+
+	// 게임 통계
+	private Integer gamesPlayed;        // 참여한 게임 수
+	private Integer gamesWon;           // 1등 횟수
+	private Integer correctGuesses;     // 정답 맞춘 횟수
+	private Integer totalGameScore;     // 누적 게임 점수
+	private Integer quickGuesses;       // 5초 내 정답 횟수
+	private Integer perfectDraws;       // 전원 정답 유도 횟수
+
 	// 메타데이터
 	private String createdAt;
 	private String updatedAt;


### PR DESCRIPTION
## Summary
- UserStats에 게임 통계 필드 추가
  - gamesPlayed, gamesWon, correctGuesses, totalGameScore, quickGuesses, perfectDraws
- 게임 관련 뱃지 4종 추가
  - GAME_FIRST_PLAY: 첫 게임 참여
  - GAME_10_WINS: 게임 10승
  - QUICK_GUESSER: 5초 내 정답
  - PERFECT_DRAWER: 전원 정답 유도
- BadgeService에 게임 뱃지 조건 체크 로직 추가
- UserStatsRepository에 incrementGameStats 메서드 추가 (Atomic Counter 패턴)
- GameStatsService 신규 생성
- 게임 종료 시 자동으로 통계 업데이트 및 뱃지 체크

## Test plan
- [ ] 게임 종료 시 참가자 통계 업데이트 확인
- [ ] 1등 시 gamesWon 증가 확인
- [ ] 5초 내 정답 시 QUICK_GUESSER 뱃지 획득 확인
- [ ] 전원 정답 유도 시 PERFECT_DRAWER 뱃지 획득 확인

## Related
- Closes #227
- Task #244
- Epic #221 (캐치마인드 게임 기능 Epic 완료)