### PR TITLE
refactor: DynamoDB 접근 패턴 최적화 #249

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameRound.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameRound.java
@@ -36,6 +36,7 @@ public class GameRound {
 
 	private Boolean hintUsed;       // 힌트 사용 여부
 	private String createdAt;
+	private Long ttl;               // 자동 만료 (7일 후)
 
 	@DynamoDbPartitionKey
 	@DynamoDbAttribute("PK")

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
@@ -97,7 +97,8 @@ public class GameService {
 
 		chatRoomRepository.save(room);
 
-		// 첫 라운드 기록 생성
+		// 첫 라운드 기록 생성 (7일 후 자동 삭제)
+		long ttlSeconds = Instant.now().plusSeconds(7 * 24 * 60 * 60).getEpochSecond();
 		GameRound firstRound = GameRound.builder()
 				.pk("ROOM#" + roomId + "#GAME")
 				.sk("ROUND#1")
@@ -113,6 +114,7 @@ public class GameService {
 				.guessTimes(new HashMap<>())
 				.roundScores(new HashMap<>())
 				.createdAt(Instant.now().toString())
+				.ttl(ttlSeconds)
 				.build();
 
 		gameRoundRepository.save(firstRound);
@@ -321,7 +323,8 @@ public class GameService {
 
 		chatRoomRepository.save(room);
 
-		// 다음 라운드 기록 생성
+		// 다음 라운드 기록 생성 (7일 후 자동 삭제)
+		long nextTtlSeconds = Instant.now().plusSeconds(7 * 24 * 60 * 60).getEpochSecond();
 		GameRound nextRoundRecord = GameRound.builder()
 				.pk("ROOM#" + roomId + "#GAME")
 				.sk("ROUND#" + nextRound)
@@ -337,6 +340,7 @@ public class GameService {
 				.guessTimes(new HashMap<>())
 				.roundScores(new HashMap<>())
 				.createdAt(Instant.now().toString())
+				.ttl(nextTtlSeconds)
 				.build();
 
 		gameRoundRepository.save(nextRoundRecord);


### PR DESCRIPTION
## Summary
- DynamoDB 접근 패턴을 검토하고 성능/비용 최적화 적용
- BatchWriteItem 활용 및 TTL 자동 만료 설정

## Changes

### GameRoundRepository - BatchWriteItem 최적화
- `deleteByRoomId()`: 개별 DeleteItem → BatchWriteItem
- DynamoDB BatchWriteItem은 최대 25개까지 지원하므로 분할 처리
- N번의 API 호출 → ceil(N/25)번으로 감소

### GameRound 모델 - TTL 추가
- `ttl` 필드 추가 (7일 후 자동 만료)
- 게임 종료 후 불필요한 라운드 데이터 자동 정리
- DynamoDB TTL 기능 활용으로 스토리지 비용 절감

## 기존 최적화 패턴 검증 완료
- **Atomic Counter 패턴**: UserStatsRepository (incrementTestStats, incrementWordsLearned, incrementGameStats)
- **BatchGetItem 패턴**: WordRepository (findByIds)
- **GSI 활용**: Query 사용, Scan 최소화
- **Cursor 페이지네이션**: OOM 방지

## Test
- `./gradlew build` 성공

Closes #254