### PR TITLE
refactor: 서비스 레이어 디자인 패턴 개선 #250

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameService.java
@@ -34,12 +34,25 @@ public class GameService {
 	private final WordRepository wordRepository;
 	private final GameStatsService gameStatsService;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameService() {
-		this.chatRoomRepository = new ChatRoomRepository();
-		this.connectionRepository = new ConnectionRepository();
-		this.gameRoundRepository = new GameRoundRepository();
-		this.wordRepository = new WordRepository();
-		this.gameStatsService = new GameStatsService();
+		this(new ChatRoomRepository(), new ConnectionRepository(),
+				new GameRoundRepository(), new WordRepository(), new GameStatsService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameService(ChatRoomRepository chatRoomRepository, ConnectionRepository connectionRepository,
+	                   GameRoundRepository gameRoundRepository, WordRepository wordRepository,
+	                   GameStatsService gameStatsService) {
+		this.chatRoomRepository = chatRoomRepository;
+		this.connectionRepository = connectionRepository;
+		this.gameRoundRepository = gameRoundRepository;
+		this.wordRepository = wordRepository;
+		this.gameStatsService = gameStatsService;
 	}
 
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/factory/WordFactory.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/factory/WordFactory.java
@@ -1,0 +1,73 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.factory;
+
+import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Word 엔티티 생성 Factory
+ * 객체 생성 로직을 중앙 집중화하여 일관성 유지
+ */
+public class WordFactory {
+
+	private static final String DEFAULT_LEVEL = "BEGINNER";
+	private static final String DEFAULT_CATEGORY = "DAILY";
+
+	/**
+	 * 새 Word 엔티티 생성
+	 */
+	public Word create(String english, String korean, String example, String level, String category) {
+		String wordId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+		String resolvedLevel = level != null ? level : DEFAULT_LEVEL;
+		String resolvedCategory = category != null ? category : DEFAULT_CATEGORY;
+
+		return Word.builder()
+				.pk("WORD#" + wordId)
+				.sk("METADATA")
+				.gsi1pk("LEVEL#" + resolvedLevel)
+				.gsi1sk("WORD#" + wordId)
+				.gsi2pk("CATEGORY#" + resolvedCategory)
+				.gsi2sk("WORD#" + wordId)
+				.wordId(wordId)
+				.english(english)
+				.korean(korean)
+				.example(example)
+				.level(resolvedLevel)
+				.category(resolvedCategory)
+				.createdAt(now)
+				.build();
+	}
+
+	/**
+	 * 기본값으로 Word 생성
+	 */
+	public Word create(String english, String korean, String example) {
+		return create(english, korean, example, DEFAULT_LEVEL, DEFAULT_CATEGORY);
+	}
+
+	/**
+	 * Word 엔티티 업데이트 (GSI 키 자동 갱신)
+	 */
+	public Word updateFields(Word word, String english, String korean, String example, String level, String category) {
+		if (english != null) {
+			word.setEnglish(english);
+		}
+		if (korean != null) {
+			word.setKorean(korean);
+		}
+		if (example != null) {
+			word.setExample(example);
+		}
+		if (level != null) {
+			word.setLevel(level);
+			word.setGsi1pk("LEVEL#" + level);
+		}
+		if (category != null) {
+			word.setCategory(category);
+			word.setGsi2pk("CATEGORY#" + category);
+		}
+		return word;
+	}
+}


### PR DESCRIPTION
## Summary
- 서비스 레이어의 디자인 패턴을 개선하여 유지보수성과 테스트 용이성 향상
- Factory 패턴 및 의존성 주입 패턴 적용

## Changes

### Factory 패턴 적용
- **WordFactory 생성**: Word 엔티티 생성 로직 중앙 집중화
  - `create()`: 새 Word 생성 (PK/SK/GSI 키 자동 설정)
  - `updateFields()`: 필드 업데이트 (GSI 키 자동 갱신)
  - 기본값 처리 (level: BEGINNER, category: DAILY)

### 의존성 주입 개선
- **WordService**: 생성자 주입 추가
  ```java
  // Lambda용 기본 생성자
  public WordService() {
      this(new WordRepository(), new WordFactory());
  }
  // 테스트용 의존성 주입 생성자
  public WordService(WordRepository repo, WordFactory factory) { ... }
  ```
- **GameService**: 5개 의존성에 대한 생성자 주입 추가

### 코드 간소화
- WordService의 중복된 Word 생성 로직 제거 (createWord, createWordsBatch)
- updateWord에서 조건부 업데이트 로직 Factory로 이전

## 기존 패턴 검증 완료
- CQRS 패턴: Command/Query 서비스 분리 (ChatRoom, Word, UserWord, Test 등)
- Factory 패턴: ChatResponseFactory (AI 응답 생성)
- Router 패턴: HandlerRouter (REST API 라우팅)

## Test
- `./gradlew build` 성공

Closes #256