### PR TITLE
refactor: 공통 유틸리티 및 중복 코드 정리 #251

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/constants/DynamoDbKey.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/constants/DynamoDbKey.java
@@ -1,7 +1,11 @@
 package com.mzc.secondproject.serverless.common.constants;
 
+/**
+ * DynamoDB 공통 키 상수 및 빌더
+ * 모든 도메인에서 공통으로 사용되는 키 패턴 정의
+ */
 public final class DynamoDbKey {
-	
+
 	// Partition/Sort Key Attributes
 	public static final String PK = "PK";
 	public static final String SK = "SK";
@@ -20,7 +24,15 @@ public final class DynamoDbKey {
 	public static final String METADATA = "METADATA";
 	// 공용 Entity Prefix
 	public static final String USER = "USER#";
-	
+
 	private DynamoDbKey() {
+	}
+
+	/**
+	 * 사용자 PK 생성 (공통)
+	 * 여러 도메인에서 동일한 패턴으로 사용
+	 */
+	public static String userPk(String userId) {
+		return USER + userId;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/constants/ChatKey.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/constants/ChatKey.java
@@ -15,19 +15,16 @@ public final class ChatKey {
 	private ChatKey() {
 	}
 	
-	// Key Builders
+	// Key Builders (userPk는 DynamoDbKey.userPk() 사용)
+
 	public static String roomPk(String roomId) {
 		return ROOM + roomId;
 	}
-	
+
 	public static String messageSk(String messageId) {
 		return MESSAGE + messageId;
 	}
-	
-	public static String userPk(String userId) {
-		return DynamoDbKey.USER + userId;
-	}
-	
+
 	public static String connectionPk(String connectionId) {
 		return CONNECTION + connectionId;
 	}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/constants/VocabKey.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/constants/VocabKey.java
@@ -23,11 +23,8 @@ public final class VocabKey {
 	private VocabKey() {
 	}
 	
-	// Key Builders
-	public static String userPk(String userId) {
-		return DynamoDbKey.USER + userId;
-	}
-	
+	// Key Builders (userPk는 DynamoDbKey.userPk() 사용)
+
 	public static String wordPk(String wordId) {
 		return WORD + wordId;
 	}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/factory/WordFactory.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/factory/WordFactory.java
@@ -1,5 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.factory;
 
+import com.mzc.secondproject.serverless.common.constants.DynamoDbKey;
+import com.mzc.secondproject.serverless.domain.vocabulary.constants.VocabKey;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
 
 import java.time.Instant;
@@ -24,12 +26,12 @@ public class WordFactory {
 		String resolvedCategory = category != null ? category : DEFAULT_CATEGORY;
 
 		return Word.builder()
-				.pk("WORD#" + wordId)
-				.sk("METADATA")
-				.gsi1pk("LEVEL#" + resolvedLevel)
-				.gsi1sk("WORD#" + wordId)
-				.gsi2pk("CATEGORY#" + resolvedCategory)
-				.gsi2sk("WORD#" + wordId)
+				.pk(VocabKey.wordPk(wordId))
+				.sk(DynamoDbKey.METADATA)
+				.gsi1pk(VocabKey.levelPk(resolvedLevel))
+				.gsi1sk(VocabKey.wordSk(wordId))
+				.gsi2pk(VocabKey.categoryPk(resolvedCategory))
+				.gsi2sk(VocabKey.wordSk(wordId))
 				.wordId(wordId)
 				.english(english)
 				.korean(korean)
@@ -62,11 +64,11 @@ public class WordFactory {
 		}
 		if (level != null) {
 			word.setLevel(level);
-			word.setGsi1pk("LEVEL#" + level);
+			word.setGsi1pk(VocabKey.levelPk(level));
 		}
 		if (category != null) {
 			word.setCategory(category);
-			word.setGsi2pk("CATEGORY#" + category);
+			word.setGsi2pk(VocabKey.categoryPk(category));
 		}
 		return word;
 	}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/UserWordCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/UserWordCommandService.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
 import com.mzc.secondproject.serverless.common.config.StudyConfig;
+import com.mzc.secondproject.serverless.common.constants.DynamoDbKey;
 import com.mzc.secondproject.serverless.common.enums.Difficulty;
 import com.mzc.secondproject.serverless.domain.vocabulary.constants.VocabKey;
 import com.mzc.secondproject.serverless.domain.vocabulary.enums.WordStatus;
@@ -36,7 +37,7 @@ public class UserWordCommandService {
 		
 		if (optUserWord.isEmpty()) {
 			userWord = UserWord.builder()
-					.pk(VocabKey.userPk(userId))
+					.pk(DynamoDbKey.userPk(userId))
 					.sk(VocabKey.wordSk(wordId))
 					.gsi1pk(VocabKey.userReviewPk(userId))
 					.gsi2pk(VocabKey.userStatusPk(userId))
@@ -75,7 +76,7 @@ public class UserWordCommandService {
 		
 		if (optUserWord.isEmpty()) {
 			userWord = UserWord.builder()
-					.pk(VocabKey.userPk(userId))
+					.pk(DynamoDbKey.userPk(userId))
 					.sk(VocabKey.wordSk(wordId))
 					.gsi1pk(VocabKey.userReviewPk(userId))
 					.gsi2pk(VocabKey.userStatusPk(userId))
@@ -137,7 +138,7 @@ public class UserWordCommandService {
 		
 		if (optUserWord.isEmpty()) {
 			userWord = UserWord.builder()
-					.pk(VocabKey.userPk(userId))
+					.pk(DynamoDbKey.userPk(userId))
 					.sk(VocabKey.wordSk(wordId))
 					.gsi1pk(VocabKey.userReviewPk(userId))
 					.gsi2pk(VocabKey.userStatusPk(userId))


### PR DESCRIPTION
## Summary
- 공통 유틸리티 클래스 정리 및 중복 코드 제거
- DynamoDB 키 상수 일관성 확보

## Changes

### 중복 유틸리티 통합
- **DynamoDbKey.userPk()**: 공통 메서드로 추가
  ```java
  public static String userPk(String userId) {
      return USER + userId;
  }
  ```
- **VocabKey, ChatKey**: 중복된 `userPk()` 메서드 제거
- **UserWordCommandService**: `DynamoDbKey.userPk()` 사용으로 변경

### 상수 적용 (WordFactory)
- 하드코딩된 키 패턴을 상수로 교체:
  - `"WORD#" + wordId` → `VocabKey.wordPk(wordId)`
  - `"METADATA"` → `DynamoDbKey.METADATA`
  - `"LEVEL#" + level` → `VocabKey.levelPk(level)`
  - `"CATEGORY#" + category` → `VocabKey.categoryPk(category)`

## 개선 효과
- 키 생성 로직 중앙 집중화로 일관성 확보
- 오타로 인한 버그 방지
- 키 패턴 변경 시 한 곳만 수정

## Test
- `./gradlew build` 성공

Closes #258