### PR TITLE
fix: GameHandler 환경변수 및 WebSocket API 참조 수정

### DIFF
--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -339,6 +339,9 @@ Resources:
       Description: Handle catch-mind game operations
       SnapStart:
         ApplyOn: PublishedVersions
+      Environment:
+        Variables:
+          WEBSOCKET_ENDPOINT: !Sub "https://${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ChatTable
@@ -346,7 +349,7 @@ Resources:
             - Effect: Allow
               Action:
                 - execute-api:ManageConnections
-              Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ChatWebSocketApi}/*"
+              Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*"
       Events:
         StartGame:
           Type: Api


### PR DESCRIPTION
## Summary
- GameFunction에 WEBSOCKET_ENDPOINT 환경변수 추가
- ChatWebSocketApi를 WebSocketApi로 수정 (오타 수정)

## 변경 내용
### GameFunction 환경변수 추가
`WebSocketBroadcaster`가 초기화될 때 `WEBSOCKET_ENDPOINT` 환경변수가 필요합니다.
기존에 이 환경변수가 누락되어 Lambda 실행 시 NullPointerException이 발생했습니다.

### WebSocket API 참조 수정
`ChatWebSocketApi`는 존재하지 않는 리소스 참조였습니다.
올바른 리소스 이름인 `WebSocketApi`로 수정했습니다.

## Test plan
- [x] 배포 후 Game Status API 테스트 (`GET /chat/rooms/{roomId}/game/status`)
- [x] Game Start API 테스트 (`POST /chat/rooms/{roomId}/game/start`)
- [x] Game Scores API 테스트 (`GET /chat/rooms/{roomId}/game/scores`)