### PR TITLE
refactor: WebSocket 핸들러 유틸리티 공통화 및 코드 품질 개선

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/WebSocketEventUtil.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/WebSocketEventUtil.java
@@ -1,0 +1,80 @@
+package com.mzc.secondproject.serverless.common.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * WebSocket 이벤트 처리 유틸리티
+ * 공통 메서드를 제공하여 핸들러 간 코드 중복 제거
+ */
+public final class WebSocketEventUtil {
+
+	private WebSocketEventUtil() {
+		// 유틸리티 클래스 인스턴스화 방지
+	}
+
+	/**
+	 * WebSocket 이벤트에서 connectionId 추출
+	 */
+	@SuppressWarnings("unchecked")
+	public static String extractConnectionId(Map<String, Object> event) {
+		Map<String, Object> requestContext = (Map<String, Object>) event.get("requestContext");
+		return (String) requestContext.get("connectionId");
+	}
+
+	/**
+	 * WebSocket 이벤트에서 queryStringParameters 추출
+	 */
+	@SuppressWarnings("unchecked")
+	public static Map<String, String> extractQueryStringParameters(Map<String, Object> event) {
+		Map<String, String> params = (Map<String, String>) event.get("queryStringParameters");
+		return params != null ? params : new HashMap<>();
+	}
+
+	/**
+	 * WebSocket 이벤트에서 endpoint URL 추출
+	 * API Gateway Management API 호출에 사용
+	 */
+	@SuppressWarnings("unchecked")
+	public static String extractWebSocketEndpoint(Map<String, Object> event) {
+		Map<String, Object> requestContext = (Map<String, Object>) event.get("requestContext");
+		String domainName = (String) requestContext.get("domainName");
+		String stage = (String) requestContext.get("stage");
+		return "https://" + domainName + "/" + stage;
+	}
+
+	/**
+	 * WebSocket 응답 생성
+	 */
+	public static Map<String, Object> createResponse(int statusCode, String body) {
+		return Map.of("statusCode", statusCode, "body", body);
+	}
+
+	/**
+	 * 성공 응답 생성 (200)
+	 */
+	public static Map<String, Object> ok(String message) {
+		return createResponse(200, message);
+	}
+
+	/**
+	 * 인증 실패 응답 생성 (401)
+	 */
+	public static Map<String, Object> unauthorized(String message) {
+		return createResponse(401, message);
+	}
+
+	/**
+	 * 서버 에러 응답 생성 (500)
+	 */
+	public static Map<String, Object> serverError(String message) {
+		return createResponse(500, message);
+	}
+
+	/**
+	 * 잘못된 요청 응답 생성 (400)
+	 */
+	public static Map<String, Object> badRequest(String message) {
+		return createResponse(400, message);
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketConnectHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketConnectHandler.java
@@ -3,6 +3,7 @@ package com.mzc.secondproject.serverless.domain.chatting.handler.websocket;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.mzc.secondproject.serverless.common.config.WebSocketConfig;
+import com.mzc.secondproject.serverless.common.util.WebSocketEventUtil;
 import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
 import com.mzc.secondproject.serverless.domain.chatting.model.RoomToken;
 import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
@@ -11,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -34,32 +34,32 @@ public class WebSocketConnectHandler implements RequestHandler<Map<String, Objec
 	@Override
 	public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
 		logger.info("WebSocket connect event: {}", event);
-		
+
 		try {
-			String connectionId = extractConnectionId(event);
-			Map<String, String> queryParams = extractQueryStringParameters(event);
-			
+			String connectionId = WebSocketEventUtil.extractConnectionId(event);
+			Map<String, String> queryParams = WebSocketEventUtil.extractQueryStringParameters(event);
+
 			String roomToken = queryParams.get("roomToken");
-			
+
 			if (roomToken == null || roomToken.isEmpty()) {
 				logger.warn("Missing roomToken parameter");
-				return createResponse(401, "roomToken is required");
+				return WebSocketEventUtil.unauthorized("roomToken is required");
 			}
-			
+
 			// 토큰 검증
 			Optional<RoomToken> optToken = roomTokenService.validateToken(roomToken);
 			if (optToken.isEmpty()) {
 				logger.warn("Invalid or expired roomToken: {}", roomToken);
-				return createResponse(401, "Invalid or expired token");
+				return WebSocketEventUtil.unauthorized("Invalid or expired token");
 			}
-			
+
 			RoomToken token = optToken.get();
 			String userId = token.getUserId();
 			String roomId = token.getRoomId();
-			
+
 			String now = Instant.now().toString();
 			long ttl = Instant.now().plusSeconds(WebSocketConfig.connectionTtlSeconds()).getEpochSecond();
-			
+
 			Connection connection = Connection.builder()
 					.pk("CONN#" + connectionId)
 					.sk("METADATA")
@@ -73,34 +73,15 @@ public class WebSocketConnectHandler implements RequestHandler<Map<String, Objec
 					.connectedAt(now)
 					.ttl(ttl)
 					.build();
-			
+
 			connectionRepository.save(connection);
-			
+
 			logger.info("Connection saved: connectionId={}, userId={}, roomId={}", connectionId, userId, roomId);
-			return createResponse(200, "Connected");
-			
+			return WebSocketEventUtil.ok("Connected");
+
 		} catch (Exception e) {
 			logger.error("Error handling connect: {}", e.getMessage(), e);
-			return createResponse(500, "Internal server error");
+			return WebSocketEventUtil.serverError("Internal server error");
 		}
-	}
-	
-	@SuppressWarnings("unchecked")
-	private String extractConnectionId(Map<String, Object> event) {
-		Map<String, Object> requestContext = (Map<String, Object>) event.get("requestContext");
-		return (String) requestContext.get("connectionId");
-	}
-	
-	@SuppressWarnings("unchecked")
-	private Map<String, String> extractQueryStringParameters(Map<String, Object> event) {
-		Map<String, String> params = (Map<String, String>) event.get("queryStringParameters");
-		return params != null ? params : new HashMap<>();
-	}
-	
-	private Map<String, Object> createResponse(int statusCode, String body) {
-		Map<String, Object> response = new HashMap<>();
-		response.put("statusCode", statusCode);
-		response.put("body", body);
-		return response;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketDisconnectHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/websocket/WebSocketDisconnectHandler.java
@@ -2,12 +2,12 @@ package com.mzc.secondproject.serverless.domain.chatting.handler.websocket;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.mzc.secondproject.serverless.common.util.WebSocketEventUtil;
 import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
 import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,12 +28,12 @@ public class WebSocketDisconnectHandler implements RequestHandler<Map<String, Ob
 	@Override
 	public Map<String, Object> handleRequest(Map<String, Object> event, Context context) {
 		logger.info("WebSocket disconnect event: {}", event);
-		
+
 		try {
-			String connectionId = extractConnectionId(event);
-			
+			String connectionId = WebSocketEventUtil.extractConnectionId(event);
+
 			Optional<Connection> connection = connectionRepository.findByConnectionId(connectionId);
-			
+
 			if (connection.isPresent()) {
 				Connection conn = connection.get();
 				connectionRepository.delete(connectionId);
@@ -42,25 +42,12 @@ public class WebSocketDisconnectHandler implements RequestHandler<Map<String, Ob
 			} else {
 				logger.warn("Connection not found for deletion: connectionId={}", connectionId);
 			}
-			
-			return createResponse(200, "Disconnected");
-			
+
+			return WebSocketEventUtil.ok("Disconnected");
+
 		} catch (Exception e) {
 			logger.error("Error handling disconnect: {}", e.getMessage(), e);
-			return createResponse(500, "Internal server error");
+			return WebSocketEventUtil.serverError("Internal server error");
 		}
-	}
-	
-	@SuppressWarnings("unchecked")
-	private String extractConnectionId(Map<String, Object> event) {
-		Map<String, Object> requestContext = (Map<String, Object>) event.get("requestContext");
-		return (String) requestContext.get("connectionId");
-	}
-	
-	private Map<String, Object> createResponse(int statusCode, String body) {
-		Map<String, Object> response = new HashMap<>();
-		response.put("statusCode", statusCode);
-		response.put("body", body);
-		return response;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/handler/websocket/GrammarStreamingConnectHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/handler/websocket/GrammarStreamingConnectHandler.java
@@ -4,12 +4,12 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.mzc.secondproject.serverless.common.config.WebSocketConfig;
 import com.mzc.secondproject.serverless.common.util.JwtUtil;
+import com.mzc.secondproject.serverless.common.util.WebSocketEventUtil;
 import com.mzc.secondproject.serverless.domain.grammar.model.GrammarConnection;
 import com.mzc.secondproject.serverless.domain.grammar.repository.GrammarConnectionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -35,28 +35,28 @@ public class GrammarStreamingConnectHandler implements RequestHandler<Map<String
 		logger.info("Grammar WebSocket connect event");
 
 		try {
-			String connectionId = extractConnectionId(event);
-			Map<String, String> queryParams = extractQueryStringParameters(event);
+			String connectionId = WebSocketEventUtil.extractConnectionId(event);
+			Map<String, String> queryParams = WebSocketEventUtil.extractQueryStringParameters(event);
 
 			// JWT 토큰 검증
 			String token = queryParams.get("token");
 
 			if (token == null || token.isEmpty()) {
 				logger.warn("Missing token parameter");
-				return createResponse(401, "token is required");
+				return WebSocketEventUtil.unauthorized("token is required");
 			}
 
 			// 토큰 유효성 검사
 			if (!JwtUtil.isValid(token)) {
 				logger.warn("Invalid or expired token");
-				return createResponse(401, "Invalid or expired token");
+				return WebSocketEventUtil.unauthorized("Invalid or expired token");
 			}
 
 			// userId 추출
 			Optional<String> userIdOpt = JwtUtil.extractUserId(token);
 			if (userIdOpt.isEmpty()) {
 				logger.warn("Failed to extract userId from token");
-				return createResponse(401, "Invalid token");
+				return WebSocketEventUtil.unauthorized("Invalid token");
 			}
 
 			String userId = userIdOpt.get();
@@ -71,27 +71,11 @@ public class GrammarStreamingConnectHandler implements RequestHandler<Map<String
 			connectionRepository.save(connection);
 
 			logger.info("Grammar connection established: connectionId={}, userId={}", connectionId, userId);
-			return createResponse(200, "Connected");
+			return WebSocketEventUtil.ok("Connected");
 
 		} catch (Exception e) {
 			logger.error("Error handling connect: {}", e.getMessage(), e);
-			return createResponse(500, "Internal server error");
+			return WebSocketEventUtil.serverError("Internal server error");
 		}
-	}
-
-	@SuppressWarnings("unchecked")
-	private String extractConnectionId(Map<String, Object> event) {
-		Map<String, Object> requestContext = (Map<String, Object>) event.get("requestContext");
-		return (String) requestContext.get("connectionId");
-	}
-
-	@SuppressWarnings("unchecked")
-	private Map<String, String> extractQueryStringParameters(Map<String, Object> event) {
-		Map<String, String> params = (Map<String, String>) event.get("queryStringParameters");
-		return params != null ? params : new HashMap<>();
-	}
-
-	private Map<String, Object> createResponse(int statusCode, String body) {
-		return Map.of("statusCode", statusCode, "body", body);
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/handler/websocket/GrammarStreamingDisconnectHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/handler/websocket/GrammarStreamingDisconnectHandler.java
@@ -2,6 +2,7 @@ package com.mzc.secondproject.serverless.domain.grammar.handler.websocket;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.mzc.secondproject.serverless.common.util.WebSocketEventUtil;
 import com.mzc.secondproject.serverless.domain.grammar.repository.GrammarConnectionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,27 +28,17 @@ public class GrammarStreamingDisconnectHandler implements RequestHandler<Map<Str
 		logger.info("Grammar WebSocket disconnect event");
 
 		try {
-			String connectionId = extractConnectionId(event);
+			String connectionId = WebSocketEventUtil.extractConnectionId(event);
 
 			// 연결 정보 삭제
 			connectionRepository.delete(connectionId);
 
 			logger.info("Grammar connection closed: connectionId={}", connectionId);
-			return createResponse(200, "Disconnected");
+			return WebSocketEventUtil.ok("Disconnected");
 
 		} catch (Exception e) {
 			logger.error("Error handling disconnect: {}", e.getMessage(), e);
-			return createResponse(500, "Internal server error");
+			return WebSocketEventUtil.serverError("Internal server error");
 		}
-	}
-
-	@SuppressWarnings("unchecked")
-	private String extractConnectionId(Map<String, Object> event) {
-		Map<String, Object> requestContext = (Map<String, Object>) event.get("requestContext");
-		return (String) requestContext.get("connectionId");
-	}
-
-	private Map<String, Object> createResponse(int statusCode, String body) {
-		return Map.of("statusCode", statusCode, "body", body);
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/model/GrammarConnection.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/model/GrammarConnection.java
@@ -17,6 +17,12 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.*;
 @DynamoDbBean
 public class GrammarConnection {
 
+	// DynamoDB Key Prefixes
+	public static final String PK_PREFIX = "GRAMMAR_CONN#";
+	public static final String SK_METADATA = "METADATA";
+	public static final String GSI1PK_PREFIX = "GRAMMAR_USER#";
+	public static final String GSI1SK_PREFIX = "CONN#";
+
 	private String pk;          // GRAMMAR_CONN#{connectionId}
 	private String sk;          // METADATA
 	private String gsi1pk;      // GRAMMAR_USER#{userId}
@@ -59,10 +65,10 @@ public class GrammarConnection {
 		long ttl = java.time.Instant.now().plusSeconds(ttlSeconds).getEpochSecond();
 
 		return GrammarConnection.builder()
-				.pk("GRAMMAR_CONN#" + connectionId)
-				.sk("METADATA")
-				.gsi1pk("GRAMMAR_USER#" + userId)
-				.gsi1sk("CONN#" + connectionId)
+				.pk(PK_PREFIX + connectionId)
+				.sk(SK_METADATA)
+				.gsi1pk(GSI1PK_PREFIX + userId)
+				.gsi1sk(GSI1SK_PREFIX + connectionId)
 				.connectionId(connectionId)
 				.userId(userId)
 				.connectedAt(now)

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarConnectionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarConnectionRepository.java
@@ -41,8 +41,8 @@ public class GrammarConnectionRepository {
 	 */
 	public Optional<GrammarConnection> findByConnectionId(String connectionId) {
 		Key key = Key.builder()
-				.partitionValue("GRAMMAR_CONN#" + connectionId)
-				.sortValue("METADATA")
+				.partitionValue(GrammarConnection.PK_PREFIX + connectionId)
+				.sortValue(GrammarConnection.SK_METADATA)
 				.build();
 
 		GrammarConnection connection = table.getItem(key);
@@ -54,8 +54,8 @@ public class GrammarConnectionRepository {
 	 */
 	public void delete(String connectionId) {
 		Key key = Key.builder()
-				.partitionValue("GRAMMAR_CONN#" + connectionId)
-				.sortValue("METADATA")
+				.partitionValue(GrammarConnection.PK_PREFIX + connectionId)
+				.sortValue(GrammarConnection.SK_METADATA)
 				.build();
 
 		table.deleteItem(key);

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/service/GrammarConversationService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/service/GrammarConversationService.java
@@ -26,6 +26,7 @@ public class GrammarConversationService {
 	private static final Logger logger = LoggerFactory.getLogger(GrammarConversationService.class);
 	private static final int SESSION_TTL_DAYS = 30;
 	private static final int MAX_HISTORY_MESSAGES = 10;
+	private static final int LAST_MESSAGE_MAX_LENGTH = 100;
 
 	private final BedrockGrammarCheckFactory grammarFactory;
 	private final GrammarSessionRepository repository;
@@ -194,7 +195,7 @@ public class GrammarConversationService {
 		String now = Instant.now().toString();
 		session.setGsi1sk(GrammarKey.updatedSk(now));
 		session.setMessageCount(session.getMessageCount() + 2); // user + assistant
-		session.setLastMessage(truncateMessage(lastMessage, 100));
+		session.setLastMessage(truncateMessage(lastMessage, LAST_MESSAGE_MAX_LENGTH));
 		session.setUpdatedAt(now);
 
 		repository.saveSession(session);


### PR DESCRIPTION
## Summary
- WebSocketEventUtil 공통 유틸리티 클래스 생성하여 6개 핸들러 코드 중복 제거
- GrammarCheckResponse 파싱 로직 통합
- 민감정보 로깅 제거 및 상수화 작업

## 변경사항

### 신규 파일
- `WebSocketEventUtil.java` - WebSocket 이벤트 처리 공통 유틸리티

### 수정 파일
- Grammar WebSocket 핸들러 3개 - 공통 유틸 사용으로 중복 제거
- Chatting WebSocket 핸들러 3개 - 공통 유틸 사용으로 중복 제거
- `BedrockGrammarCheckFactory.java` - 파싱 로직 통합, 로깅 개선, 예외 처리 개선
- `GrammarConnection.java` - DynamoDB key prefix 상수화
- `GrammarConnectionRepository.java` - 상수 사용
- `GrammarConversationService.java` - LAST_MESSAGE_MAX_LENGTH 상수화

## 개선 내용

| 항목 | 변경 전 | 변경 후 |
|------|--------|--------|
| 중복 코드 | 6개 핸들러에서 동일 메서드 반복 | WebSocketEventUtil 공통화 |
| 파싱 로직 | 2개 메서드에서 중복 | parseGrammarCheckFromJson 재사용 |
| 로깅 | 전체 응답 로깅 | 길이만 로깅 |
| 상수 | 매직 넘버/스트링 사용 | 상수로 정의 |
| 예외 처리 | InterruptedException 처리 미흡 | 스레드 인터럽트 상태 복원 |

## Test plan
- [x] 빌드 성공 확인
- [ ] Grammar WebSocket 연결/메시지 테스트
- [ ] Chatting WebSocket 연결/메시지 테스트

Closes #296