### PR TITLE
feat: Kinesis Firehose S3 아카이빙 구현

### DIFF
--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -1587,6 +1587,83 @@ Resources:
             BatchSize: 100
             MaximumBatchingWindowInSeconds: 5
 
+  #############################################
+  # Kinesis Firehose (S3 Archiving)
+  #############################################
+
+  # S3 Bucket for ranking event logs
+  RankingLogBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "${AWS::StackName}-ranking-logs"
+      LifecycleConfiguration:
+        Rules:
+          - Id: MoveToGlacierAfter90Days
+            Status: Enabled
+            Transitions:
+              - StorageClass: GLACIER
+                TransitionInDays: 90
+            ExpirationInDays: 365
+
+  # IAM Role for Firehose to access Kinesis and S3
+  FirehoseDeliveryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-firehose-delivery-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: FirehoseS3Access
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                  - s3:PutObject
+                Resource:
+                  - !GetAtt RankingLogBucket.Arn
+                  - !Sub "${RankingLogBucket.Arn}/*"
+        - PolicyName: FirehoseKinesisAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - kinesis:DescribeStream
+                  - kinesis:GetShardIterator
+                  - kinesis:GetRecords
+                  - kinesis:ListShards
+                Resource: !GetAtt RankingEventStream.Arn
+
+  # Kinesis Firehose Delivery Stream
+  RankingEventFirehose:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: !Sub "${AWS::StackName}-ranking-firehose"
+      DeliveryStreamType: KinesisStreamAsSource
+      KinesisStreamSourceConfiguration:
+        KinesisStreamARN: !GetAtt RankingEventStream.Arn
+        RoleARN: !GetAtt FirehoseDeliveryRole.Arn
+      S3DestinationConfiguration:
+        BucketARN: !GetAtt RankingLogBucket.Arn
+        Prefix: "ranking-events/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/"
+        ErrorOutputPrefix: "errors/!{firehose:error-output-type}/year=!{timestamp:yyyy}/month=!{timestamp:MM}/day=!{timestamp:dd}/"
+        BufferingHints:
+          IntervalInSeconds: 300
+          SizeInMBs: 5
+        CompressionFormat: UNCOMPRESSED
+        RoleARN: !GetAtt FirehoseDeliveryRole.Arn
+
   # Statistics Processor Lambda - SQS에서 메시지 소비하여 통계 업데이트
   StatisticsProcessorFunction:
     Type: AWS::Serverless::Function
@@ -1654,3 +1731,11 @@ Outputs:
   RankingStreamArn:
     Description: Kinesis Data Stream ARN
     Value: !GetAtt RankingEventStream.Arn
+
+  RankingFirehoseName:
+    Description: Kinesis Firehose Delivery Stream Name
+    Value: !Ref RankingEventFirehose
+
+  RankingLogBucketName:
+    Description: S3 Bucket for ranking event logs
+    Value: !Ref RankingLogBucket


### PR DESCRIPTION
## Summary
- Kinesis Firehose Delivery Stream 구현으로 랭킹 이벤트 S3 아카이빙
- S3 버킷 Lifecycle 정책 설정 (90일 후 Glacier 이동, 365일 후 삭제)
- 날짜별 파티셔닝으로 효율적인 쿼리 지원

## Changes
- `template.yaml`:
  - `RankingLogBucket`: S3 버킷 (Lifecycle 정책 포함)
  - `FirehoseDeliveryRole`: Firehose IAM 역할
  - `RankingEventFirehose`: Kinesis Firehose Delivery Stream

## S3 Structure
```
s3://${AWS::StackName}-ranking-logs/
└── ranking-events/
    └── year=2026/
        └── month=01/
            └── day=16/
                └── ranking-firehose-1-2026-01-16-10-30-00.json
```

## Buffering Settings
- Interval: 300 seconds (5 minutes)
- Size: 5 MB

## Lifecycle Policy
- 90일 후 Glacier로 전환
- 365일 후 삭제

## Test Plan
- [ ] Firehose Delivery Stream 생성 확인
- [ ] S3 버킷 생성 및 파티셔닝 확인
- [ ] 이벤트 수집 후 S3 저장 확인

closes #338, closes #349, closes #350