### PR TITLE
feat : OPIc 세션, 질문 마스터, 답변/피드백 모델 클래스 생성

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/model/OPIcAnswer.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/model/OPIcAnswer.java
@@ -1,0 +1,153 @@
+package com.mzc.secondproject.serverless.domain.opic.model;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+import java.time.Instant;
+
+/**
+ * OPIc 답변 + 피드백
+ */
+public class OPIcAnswer {
+
+    private String pk;                    // SESSION#sessionId
+    private String sk;                    // Q#01 (질문 순서)
+
+    private String sessionId;
+    private String questionId;
+    private int questionIndex;            // 질문 순서 (0, 1, 2)
+
+    // 질문 정보 (비정규화)
+    private String questionText;
+
+    // 사용자 답변
+    private String audioS3Key;            // 답변 음성 S3 키
+    private String transcript;            // 음성 → 텍스트
+    private double transcriptConfidence;  // 변환 신뢰도
+    private int durationSeconds;          // 답변 길이 (초)
+
+    // AI 피드백
+    private String score;                 // 예상 등급 (IM1, IM2, IM3, IH, AL)
+    private String grammarFeedback;       // 문법 피드백 (JSON)
+    private String vocabularyFeedback;    // 어휘 피드백 (JSON)
+    private String contentFeedback;       // 내용 피드백
+    private String pronunciationFeedback; // 발음 피드백
+    private String strengths;             // 잘한 점 (JSON array)
+    private String improvements;          // 개선점 (JSON array)
+
+    // 모범 답변
+    private String sampleAnswer;          // 모범 답변 텍스트
+    private String sampleAudioS3Key;      // 모범 답변 음성 S3 키
+
+    // 메타데이터
+    private AnswerStatus status;
+    private int attemptCount;             // 시도 횟수
+    private Instant createdAt;
+    private Instant completedAt;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("PK")
+    public String getPk() { return pk; }
+    public void setPk(String pk) { this.pk = pk; }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute("SK")
+    public String getSk() { return sk; }
+    public void setSk(String sk) { this.sk = sk; }
+
+    @DynamoDbAttribute("sessionId")
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String id) { this.sessionId = id; }
+
+    @DynamoDbAttribute("questionId")
+    public String getQuestionId() { return questionId; }
+    public void setQuestionId(String id) { this.questionId = id; }
+
+    @DynamoDbAttribute("questionIndex")
+    public int getQuestionIndex() { return questionIndex; }
+    public void setQuestionIndex(int idx) { this.questionIndex = idx; }
+
+    @DynamoDbAttribute("questionText")
+    public String getQuestionText() { return questionText; }
+    public void setQuestionText(String text) { this.questionText = text; }
+
+    @DynamoDbAttribute("audioS3Key")
+    public String getAudioS3Key() { return audioS3Key; }
+    public void setAudioS3Key(String key) { this.audioS3Key = key; }
+
+    @DynamoDbAttribute("transcript")
+    public String getTranscript() { return transcript; }
+    public void setTranscript(String transcript) { this.transcript = transcript; }
+
+    @DynamoDbAttribute("transcriptConfidence")
+    public double getTranscriptConfidence() { return transcriptConfidence; }
+    public void setTranscriptConfidence(double conf) { this.transcriptConfidence = conf; }
+
+    @DynamoDbAttribute("durationSeconds")
+    public int getDurationSeconds() { return durationSeconds; }
+    public void setDurationSeconds(int duration) { this.durationSeconds = duration; }
+
+    @DynamoDbAttribute("score")
+    public String getScore() { return score; }
+    public void setScore(String score) { this.score = score; }
+
+    @DynamoDbAttribute("grammarFeedback")
+    public String getGrammarFeedback() { return grammarFeedback; }
+    public void setGrammarFeedback(String feedback) { this.grammarFeedback = feedback; }
+
+    @DynamoDbAttribute("vocabularyFeedback")
+    public String getVocabularyFeedback() { return vocabularyFeedback; }
+    public void setVocabularyFeedback(String feedback) { this.vocabularyFeedback = feedback; }
+
+    @DynamoDbAttribute("contentFeedback")
+    public String getContentFeedback() { return contentFeedback; }
+    public void setContentFeedback(String feedback) { this.contentFeedback = feedback; }
+
+    @DynamoDbAttribute("pronunciationFeedback")
+    public String getPronunciationFeedback() { return pronunciationFeedback; }
+    public void setPronunciationFeedback(String feedback) { this.pronunciationFeedback = feedback; }
+
+    @DynamoDbAttribute("strengths")
+    public String getStrengths() { return strengths; }
+    public void setStrengths(String strengths) { this.strengths = strengths; }
+
+    @DynamoDbAttribute("improvements")
+    public String getImprovements() { return improvements; }
+    public void setImprovements(String improvements) { this.improvements = improvements; }
+
+    @DynamoDbAttribute("sampleAnswer")
+    public String getSampleAnswer() { return sampleAnswer; }
+    public void setSampleAnswer(String answer) { this.sampleAnswer = answer; }
+
+    @DynamoDbAttribute("sampleAudioS3Key")
+    public String getSampleAudioS3Key() { return sampleAudioS3Key; }
+    public void setSampleAudioS3Key(String key) { this.sampleAudioS3Key = key; }
+
+    @DynamoDbAttribute("status")
+    public AnswerStatus getStatus() { return status; }
+    public void setStatus(AnswerStatus status) { this.status = status; }
+
+    @DynamoDbAttribute("attemptCount")
+    public int getAttemptCount() { return attemptCount; }
+    public void setAttemptCount(int count) { this.attemptCount = count; }
+
+    @DynamoDbAttribute("createdAt")
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant time) { this.createdAt = time; }
+
+    @DynamoDbAttribute("completedAt")
+    public Instant getCompletedAt() { return completedAt; }
+    public void setCompletedAt(Instant time) { this.completedAt = time; }
+
+    /**
+     * 답변 상태
+     */
+    public enum AnswerStatus {
+        PENDING,      // 음성 업로드 대기
+        UPLOADED,     // 음성 업로드 완료
+        PROCESSING,   // Transcribe + Bedrock 처리 중
+        COMPLETED,    // 피드백 완료
+        FAILED        // 처리 실패
+    }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/model/OPIcQuestion.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/model/OPIcQuestion.java
@@ -1,0 +1,86 @@
+package com.mzc.secondproject.serverless.domain.opic.model;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.*;
+
+/**
+ * OPIc 질문 마스터 데이터
+ */
+@DynamoDbBean
+public class OPIcQuestion {
+
+    private String pk;                    // QUESTION#questionId
+    private String sk;                    // METADATA
+    private String gsi1pk;                // TOPIC#travel
+    private String gsi1sk;                // LEVEL#IM2
+
+    private String questionId;
+    private String topic;                 // 대주제
+    private String subTopic;              // 소주제
+    private String level;                 // 난이도 (IM1, IM2, IM3, IH, AL)
+    private String questionText;          // 질문 텍스트 (영어)
+    private String questionTextKo;        // 질문 텍스트 (한국어, 참고용)
+    private String audioS3Key;            // 질문 음성 S3 키 (Polly 캐시)
+    private String tips;                  // 답변 팁
+    private int orderInSet;               // 콤보 세트 내 순서 (1, 2, 3)
+    private boolean isActive;             // 활성화 여부
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("PK")
+    public String getPk() { return pk; }
+    public void setPk(String pk) { this.pk = pk; }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute("SK")
+    public String getSk() { return sk; }
+    public void setSk(String sk) { this.sk = sk; }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "GSI1")
+    @DynamoDbAttribute("GSI1PK")
+    public String getGsi1pk() { return gsi1pk; }
+    public void setGsi1pk(String gsi1pk) { this.gsi1pk = gsi1pk; }
+
+    @DynamoDbSecondarySortKey(indexNames = "GSI1")
+    @DynamoDbAttribute("GSI1SK")
+    public String getGsi1sk() { return gsi1sk; }
+    public void setGsi1sk(String gsi1sk) { this.gsi1sk = gsi1sk; }
+
+    @DynamoDbAttribute("questionId")
+    public String getQuestionId() { return questionId; }
+    public void setQuestionId(String id) { this.questionId = id; }
+
+    @DynamoDbAttribute("topic")
+    public String getTopic() { return topic; }
+    public void setTopic(String topic) { this.topic = topic; }
+
+    @DynamoDbAttribute("subTopic")
+    public String getSubTopic() { return subTopic; }
+    public void setSubTopic(String subTopic) { this.subTopic = subTopic; }
+
+    @DynamoDbAttribute("level")
+    public String getLevel() { return level; }
+    public void setLevel(String level) { this.level = level; }
+
+    @DynamoDbAttribute("questionText")
+    public String getQuestionText() { return questionText; }
+    public void setQuestionText(String text) { this.questionText = text; }
+
+    @DynamoDbAttribute("questionTextKo")
+    public String getQuestionTextKo() { return questionTextKo; }
+    public void setQuestionTextKo(String text) { this.questionTextKo = text; }
+
+    @DynamoDbAttribute("audioS3Key")
+    public String getAudioS3Key() { return audioS3Key; }
+    public void setAudioS3Key(String key) { this.audioS3Key = key; }
+
+    @DynamoDbAttribute("tips")
+    public String getTips() { return tips; }
+    public void setTips(String tips) { this.tips = tips; }
+
+    @DynamoDbAttribute("orderInSet")
+    public int getOrderInSet() { return orderInSet; }
+    public void setOrderInSet(int order) { this.orderInSet = order; }
+
+    @DynamoDbAttribute("isActive")
+    public boolean isActive() { return isActive; }
+    public void setActive(boolean active) { this.isActive = active; }
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/model/OPIcSession.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/model/OPIcSession.java
@@ -1,0 +1,128 @@
+package com.mzc.secondproject.serverless.domain.opic.model;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.*;
+
+import java.time.Instant;
+import java.util.List;
+
+
+/**
+ * OPIc 세션
+ */
+@DynamoDbBean
+public class OPIcSession {
+
+    private String pk;                    // USER#userId
+    private String sk;                    // SESSION#date#sessionId
+    private String gsi1pk;                // SESSION#sessionId
+    private String gsi1sk;                // METADATA
+
+    private String sessionId;
+    private String userId;
+    private String topic;                 // 대주제 (travel, hobby, work 등)
+    private String subTopic;              // 소주제
+    private String targetLevel;           // 목표 레벨 (IM1, IM2, IM3, IH, AL)
+    private SessionStatus status;         // IN_PROGRESS, COMPLETED, ABANDONED
+    private int currentQuestionIndex;     // 현재 진행 중인 질문 (0, 1, 2)
+    private int totalQuestions;           // 총 질문 수 (기본 3)
+    private List<String> questionIds;     // 질문 ID 목록
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Instant completedAt;
+    private int sequenceNumber;           // 인과적 일관성용
+
+    // 종합 결과 (세션 완료 시)
+    private String overallScore;          // 종합 예상 등급
+    private String overallFeedback;       // 종합 피드백
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("PK")
+    public String getPk() { return pk; }
+    public void setPk(String pk) { this.pk = pk; }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute("SK")
+    public String getSk() { return sk; }
+    public void setSk(String sk) { this.sk = sk; }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "GSI1")
+    @DynamoDbAttribute("GSI1PK")
+    public String getGsi1pk() { return gsi1pk; }
+    public void setGsi1pk(String gsi1pk) { this.gsi1pk = gsi1pk; }
+
+    @DynamoDbSecondarySortKey(indexNames = "GSI1")
+    @DynamoDbAttribute("GSI1SK")
+    public String getGsi1sk() { return gsi1sk; }
+    public void setGsi1sk(String gsi1sk) { this.gsi1sk = gsi1sk; }
+
+    @DynamoDbAttribute("sessionId")
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String sessionId) { this.sessionId = sessionId; }
+
+    @DynamoDbAttribute("userId")
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+
+    @DynamoDbAttribute("topic")
+    public String getTopic() { return topic; }
+    public void setTopic(String topic) { this.topic = topic; }
+
+    @DynamoDbAttribute("subTopic")
+    public String getSubTopic() { return subTopic; }
+    public void setSubTopic(String subTopic) { this.subTopic = subTopic; }
+
+    @DynamoDbAttribute("targetLevel")
+    public String getTargetLevel() { return targetLevel; }
+    public void setTargetLevel(String targetLevel) { this.targetLevel = targetLevel; }
+
+    @DynamoDbAttribute("status")
+    public SessionStatus getStatus() { return status; }
+    public void setStatus(SessionStatus status) { this.status = status; }
+
+    @DynamoDbAttribute("currentQuestionIndex")
+    public int getCurrentQuestionIndex() { return currentQuestionIndex; }
+    public void setCurrentQuestionIndex(int idx) { this.currentQuestionIndex = idx; }
+
+    @DynamoDbAttribute("totalQuestions")
+    public int getTotalQuestions() { return totalQuestions; }
+    public void setTotalQuestions(int total) { this.totalQuestions = total; }
+
+    @DynamoDbAttribute("questionIds")
+    public List<String> getQuestionIds() { return questionIds; }
+    public void setQuestionIds(List<String> ids) { this.questionIds = ids; }
+
+    @DynamoDbAttribute("createdAt")
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    @DynamoDbAttribute("updatedAt")
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+
+    @DynamoDbAttribute("completedAt")
+    public Instant getCompletedAt() { return completedAt; }
+    public void setCompletedAt(Instant completedAt) { this.completedAt = completedAt; }
+
+    @DynamoDbAttribute("sequenceNumber")
+    public int getSequenceNumber() { return sequenceNumber; }
+    public void setSequenceNumber(int seq) { this.sequenceNumber = seq; }
+
+    @DynamoDbAttribute("overallScore")
+    public String getOverallScore() { return overallScore; }
+    public void setOverallScore(String score) { this.overallScore = score; }
+
+    @DynamoDbAttribute("overallFeedback")
+    public String getOverallFeedback() { return overallFeedback; }
+    public void setOverallFeedback(String feedback) { this.overallFeedback = feedback; }
+
+    /**
+     * 세션 상태
+     */
+    public enum SessionStatus {
+        IN_PROGRESS,
+        COMPLETED,
+        ABANDONED
+    }
+}
+
+


### PR DESCRIPTION
## 개요
-  OPIc 기능 관련 DynamoDB 테이블 설계
## 관련 이슈 및 작업
- Closes #365

- Closes #364

- Related #283

## 작업 내용
- [x] 테이블 스키마 설계 (PK/SK 패턴)

PK | SK | 설명
-- | -- | --
USER#userId | PROFILE | 사용자 OPIc 설정/통계
USER#userId | SESSION#2026-01-18#uuid | 세션 메타데이터
SESSION#sessId | METADATA | 세션 상세 (GSI1으로 직접 조회)
SESSION#sessId | Q#01 | 질문1 + 답변 + 피드백
SESSION#sessId | Q#02 | 질문2 + 답변 + 피드백
SESSION#sessId | Q#03 | 질문3 + 답변 + 피드백
SESSION#sessId | RESULT | 종합 결과/리포트
QUESTION#qId | METADATA | 질문 마스터 데이터
GSI1PK | GSI1SK | 용도
SESSION#sessId | METADATA (in GSI1) | 세션 ID로 직접 조회
TOPIC#travel | LEVEL#IM2 (in GSI1) | 주제+레벨별 질문 조회

<img width="1843" height="480" alt="image" src="https://github.com/user-attachments/assets/ebfb7104-d81c-4842-803d-e98f613d4cc7" />


- [x] Session, Question, Answer 모델 클래스 구현


