### PR TITLE
fix: 예외 처리 개선

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarErrorCode.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarErrorCode.java
@@ -4,6 +4,9 @@ import com.mzc.secondproject.serverless.common.exception.DomainErrorCode;
 
 public enum GrammarErrorCode implements DomainErrorCode {
 	
+	// 요청 검증 관련 에러
+	INVALID_REQUEST("GRAMMAR_000", "잘못된 요청입니다", 400),
+
 	// 문법 체크 관련 에러
 	INVALID_SENTENCE("GRAMMAR_001", "유효하지 않은 문장입니다", 400),
 	GRAMMAR_CHECK_FAILED("GRAMMAR_002", "문법 체크에 실패했습니다", 500),

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarException.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarException.java
@@ -16,8 +16,17 @@ public class GrammarException extends ServerlessException {
 		super(errorCode, cause);
 	}
 	
+	// === 요청 검증 관련 팩토리 메서드 ===
+
+	public static GrammarException invalidRequest(String field, String reason) {
+		return (GrammarException) new GrammarException(GrammarErrorCode.INVALID_REQUEST,
+				String.format("잘못된 요청입니다: %s", reason))
+				.addDetail("field", field)
+				.addDetail("reason", reason);
+	}
+
 	// === 문법 체크 관련 팩토리 메서드 ===
-	
+
 	public static GrammarException invalidSentence(String sentence) {
 		return (GrammarException) new GrammarException(GrammarErrorCode.INVALID_SENTENCE,
 				"유효하지 않은 문장입니다. 문장을 확인해주세요.")

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/service/GrammarConversationService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/service/GrammarConversationService.java
@@ -83,7 +83,7 @@ public class GrammarConversationService {
 			throw GrammarException.invalidSentence(request.getMessage());
 		}
 		if (request.getUserId() == null || request.getUserId().trim().isEmpty()) {
-			throw new IllegalArgumentException("userId is required");
+			throw GrammarException.invalidRequest("userId", "userId는 필수입니다");
 		}
 	}
 	


### PR DESCRIPTION
## 개요
GrammarConversationService에서 IllegalArgumentException을 도메인 예외로 변경

## 변경 사항
- `GrammarErrorCode`에 `INVALID_REQUEST` 에러 코드 추가
- `GrammarException`에 `invalidRequest()` 팩토리 메서드 추가
- `GrammarConversationService.validateRequest()`에서 도메인 예외 사용

## 개선 효과
- 일관된 에러 응답 형식
- 클라이언트에서 에러 타입 구분 가능

Closes #393