### PR TITLE
fix: BadgeRepository 클라이언트 초기화 패턴 통일

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/repository/BadgeRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/repository/BadgeRepository.java
@@ -5,7 +5,6 @@ import com.mzc.secondproject.serverless.domain.badge.constants.BadgeKey;
 import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -24,10 +23,7 @@ public class BadgeRepository {
 	private final DynamoDbTable<UserBadge> table;
 	
 	public BadgeRepository() {
-		DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
-				.dynamoDbClient(AwsClients.dynamoDb())
-				.build();
-		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(UserBadge.class));
+		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(UserBadge.class));
 	}
 	
 	public void save(UserBadge badge) {


### PR DESCRIPTION
## 개요
BadgeRepository에서 다른 Repository들과 다른 클라이언트 초기화 패턴 사용 문제 수정

## 변경 전
```java
DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder()
    .dynamoDbClient(AwsClients.dynamoDb())
    .build();
this.table = enhancedClient.table(TABLE_NAME, ...);
```

## 변경 후
```java
this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, ...);
```

## 개선 효과
- 다른 Repository들과 일관된 패턴
- 싱글톤 사용으로 Lambda cold start 최적화
- 코드 간소화

Closes #396