### PR TITLE
[MESP-157] 환경 변수 검증 유틸리티 추가

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/EnvConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/EnvConfig.java
@@ -1,0 +1,94 @@
+package com.mzc.secondproject.serverless.common.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 환경 변수 설정 유틸리티
+ * - 필수 환경 변수 누락 시 명확한 에러 메시지 제공
+ * - Lambda 시작 시 설정 오류를 빠르게 감지
+ */
+public final class EnvConfig {
+
+	private static final Logger logger = LoggerFactory.getLogger(EnvConfig.class);
+
+	private EnvConfig() {
+		// 유틸리티 클래스 - 인스턴스화 방지
+	}
+
+	/**
+	 * 필수 환경 변수를 가져옵니다.
+	 * 환경 변수가 설정되지 않았거나 빈 문자열인 경우 IllegalStateException을 발생시킵니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @return 환경 변수 값
+	 * @throws IllegalStateException 환경 변수가 설정되지 않은 경우
+	 */
+	public static String getRequired(String name) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			String message = String.format("필수 환경 변수 '%s'가 설정되지 않았습니다. SAM template.yaml을 확인하세요.", name);
+			logger.error(message);
+			throw new IllegalStateException(message);
+		}
+		return value;
+	}
+
+	/**
+	 * 선택적 환경 변수를 가져옵니다.
+	 * 환경 변수가 설정되지 않은 경우 기본값을 반환합니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @param defaultValue 기본값
+	 * @return 환경 변수 값 또는 기본값
+	 */
+	public static String getOrDefault(String name, String defaultValue) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			logger.debug("환경 변수 '{}'가 설정되지 않아 기본값 '{}'을 사용합니다.", name, defaultValue);
+			return defaultValue;
+		}
+		return value;
+	}
+
+	/**
+	 * 선택적 환경 변수를 정수로 가져옵니다.
+	 * 환경 변수가 설정되지 않거나 파싱에 실패한 경우 기본값을 반환합니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @param defaultValue 기본값
+	 * @return 환경 변수 값 또는 기본값
+	 */
+	public static int getIntOrDefault(String name, int defaultValue) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			return defaultValue;
+		}
+		try {
+			return Integer.parseInt(value.trim());
+		} catch (NumberFormatException e) {
+			logger.warn("환경 변수 '{}'의 값 '{}'을 정수로 변환할 수 없어 기본값 {}을 사용합니다.", name, value, defaultValue);
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * 선택적 환경 변수를 long으로 가져옵니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @param defaultValue 기본값
+	 * @return 환경 변수 값 또는 기본값
+	 */
+	public static long getLongOrDefault(String name, long defaultValue) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			return defaultValue;
+		}
+		try {
+			return Long.parseLong(value.trim());
+		} catch (NumberFormatException e) {
+			logger.warn("환경 변수 '{}'의 값 '{}'을 long으로 변환할 수 없어 기본값 {}을 사용합니다.", name, value, defaultValue);
+			return defaultValue;
+		}
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/RoomTokenConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/RoomTokenConfig.java
@@ -5,30 +5,18 @@ package com.mzc.secondproject.serverless.common.config;
  * Lambda 환경변수에서 값을 읽어오며, 없을 경우 기본값 사용
  */
 public final class RoomTokenConfig {
-	
+
 	// 환경변수 키
 	private static final String ENV_TOKEN_TTL_SECONDS = "ROOM_TOKEN_TTL_SECONDS";
 	// 기본값: 5분
 	private static final long DEFAULT_TOKEN_TTL_SECONDS = 300L;
 	// 캐시된 값 (Cold Start 최적화)
-	private static final long TOKEN_TTL_SECONDS = parseTokenTtl();
-	
+	private static final long TOKEN_TTL_SECONDS = EnvConfig.getLongOrDefault(ENV_TOKEN_TTL_SECONDS, DEFAULT_TOKEN_TTL_SECONDS);
+
 	private RoomTokenConfig() {
 		// 인스턴스화 방지
 	}
-	
-	private static long parseTokenTtl() {
-		String value = System.getenv(ENV_TOKEN_TTL_SECONDS);
-		if (value != null) {
-			try {
-				return Long.parseLong(value);
-			} catch (NumberFormatException ignored) {
-				// 파싱 실패 시 기본값 사용
-			}
-		}
-		return DEFAULT_TOKEN_TTL_SECONDS;
-	}
-	
+
 	/**
 	 * RoomToken TTL (초)
 	 */

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/WebSocketConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/WebSocketConfig.java
@@ -5,39 +5,27 @@ package com.mzc.secondproject.serverless.common.config;
  * Lambda 환경변수에서 값을 읽어오며, 없을 경우 기본값 사용
  */
 public final class WebSocketConfig {
-	
+
 	// 환경변수 키
 	private static final String ENV_CONNECTION_TTL_SECONDS = "WEBSOCKET_CONNECTION_TTL_SECONDS";
 	private static final String ENV_WEBSOCKET_ENDPOINT = "WEBSOCKET_ENDPOINT";
 	// 기본값
 	private static final long DEFAULT_CONNECTION_TTL_SECONDS = 600L; // 10분
 	// 캐시된 값 (Cold Start 최적화)
-	private static final long CONNECTION_TTL_SECONDS = parseConnectionTtl();
-	private static final String WEBSOCKET_ENDPOINT = System.getenv(ENV_WEBSOCKET_ENDPOINT);
-	
+	private static final long CONNECTION_TTL_SECONDS = EnvConfig.getLongOrDefault(ENV_CONNECTION_TTL_SECONDS, DEFAULT_CONNECTION_TTL_SECONDS);
+	private static final String WEBSOCKET_ENDPOINT = EnvConfig.getRequired(ENV_WEBSOCKET_ENDPOINT);
+
 	private WebSocketConfig() {
 		// 인스턴스화 방지
 	}
-	
-	private static long parseConnectionTtl() {
-		String value = System.getenv(ENV_CONNECTION_TTL_SECONDS);
-		if (value != null) {
-			try {
-				return Long.parseLong(value);
-			} catch (NumberFormatException ignored) {
-				// 파싱 실패 시 기본값 사용
-			}
-		}
-		return DEFAULT_CONNECTION_TTL_SECONDS;
-	}
-	
+
 	/**
 	 * WebSocket 연결 TTL (초)
 	 */
 	public static long connectionTtlSeconds() {
 		return CONNECTION_TTL_SECONDS;
 	}
-	
+
 	/**
 	 * WebSocket API Gateway 엔드포인트 URL
 	 * 메시지 브로드캐스트 시 사용

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/S3PresignUtil.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/S3PresignUtil.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.common.util;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -16,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class S3PresignUtil {
 	
 	private static final S3Presigner presigner = AwsClients.s3Presigner();
-	private static final String BUCKET_NAME = System.getenv("BUCKET_NAME");
+	private static final String BUCKET_NAME = EnvConfig.getRequired("BUCKET_NAME");
 	private static final Duration DEFAULT_DURATION = Duration.ofHours(24);
 	
 	// 캐시 (키: S3 key, 값: presigned URL, 만료시간)

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/repository/BadgeRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/repository/BadgeRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.badge.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.badge.constants.BadgeKey;
 import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
 import org.slf4j.Logger;
@@ -18,7 +19,7 @@ import java.util.Optional;
 public class BadgeRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(BadgeRepository.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<UserBadge> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatVoiceHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatVoiceHandler.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.exception.CommonErrorCode;
 import com.mzc.secondproject.serverless.common.service.PollyService;
 import com.mzc.secondproject.serverless.common.service.PollyService.VoiceSynthesisResult;
@@ -22,7 +23,7 @@ import java.util.Optional;
 public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 	
 	private static final Logger logger = LoggerFactory.getLogger(ChatVoiceHandler.class);
-	private static final String BUCKET_NAME = System.getenv("CHAT_BUCKET_NAME");
+	private static final String BUCKET_NAME = EnvConfig.getRequired("CHAT_BUCKET_NAME");
 	
 	private final PollyService pollyService;
 	private final ChatMessageRepository messageRepository;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatMessageRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.chatting.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatMessage;
@@ -21,7 +22,7 @@ import java.util.Optional;
 public class ChatMessageRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(ChatMessageRepository.class);
-	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<ChatMessage> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatRoomRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.chatting.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
@@ -24,7 +25,7 @@ import java.util.Optional;
 public class ChatRoomRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(ChatRoomRepository.class);
-	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<ChatRoom> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ConnectionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ConnectionRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.chatting.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
 public class ConnectionRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(ConnectionRepository.class);
-	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<Connection> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameRoundRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameRoundRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.chatting.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.chatting.model.GameRound;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
 public class GameRoundRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(GameRoundRepository.class);
-	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	private static final int BATCH_SIZE = 25;  // DynamoDB BatchWriteItem 최대 25개
 	
 	private final DynamoDbEnhancedClient enhancedClient;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/RoomTokenRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/RoomTokenRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.chatting.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.chatting.model.RoomToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,7 @@ import java.util.Optional;
 public class RoomTokenRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(RoomTokenRepository.class);
-	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<RoomToken> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarConnectionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarConnectionRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.grammar.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.grammar.model.GrammarConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +17,7 @@ import java.util.Optional;
 public class GrammarConnectionRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(GrammarConnectionRepository.class);
-	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<GrammarConnection> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarSessionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarSessionRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.grammar.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.grammar.constants.GrammarKey;
@@ -23,7 +24,7 @@ import java.util.Optional;
 public class GrammarSessionRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(GrammarSessionRepository.class);
-	private static final String TABLE_NAME = System.getenv("CHAT_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<GrammarSession> sessionTable;
 	private final DynamoDbTable<GrammarMessage> messageTable;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/ScheduledStatsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/ScheduledStatsHandler.java
@@ -3,6 +3,7 @@ package com.mzc.secondproject.serverless.domain.stats.handler;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +19,7 @@ import java.time.LocalDate;
 public class ScheduledStatsHandler implements RequestHandler<ScheduledEvent, String> {
 	
 	private static final Logger logger = LoggerFactory.getLogger(ScheduledStatsHandler.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final UserStatsRepository userStatsRepository;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/repository/UserStatsRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/repository/UserStatsRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.stats.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.stats.constants.StatsKey;
@@ -28,7 +29,7 @@ import java.util.*;
 public class UserStatsRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(UserStatsRepository.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<UserStats> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/VoiceHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/VoiceHandler.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.exception.CommonErrorCode;
 import com.mzc.secondproject.serverless.common.service.PollyService;
 import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
@@ -22,7 +23,7 @@ import java.util.Optional;
 public class VoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 	
 	private static final Logger logger = LoggerFactory.getLogger(VoiceHandler.class);
-	private static final String BUCKET_NAME = System.getenv("VOCAB_BUCKET_NAME");
+	private static final String BUCKET_NAME = EnvConfig.getRequired("VOCAB_BUCKET_NAME");
 	
 	private final WordRepository wordRepository;
 	private final PollyService pollyService;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/DailyStudyRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/DailyStudyRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.DailyStudy;
@@ -22,7 +23,7 @@ import java.util.Optional;
 public class DailyStudyRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(DailyStudyRepository.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<DailyStudy> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/TestResultRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/TestResultRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.TestResult;
@@ -21,7 +22,7 @@ import java.util.Optional;
 public class TestResultRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(TestResultRepository.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<TestResult> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/UserWordRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/UserWordRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.UserWord;
@@ -18,7 +19,7 @@ import java.util.Optional;
 public class UserWordRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(UserWordRepository.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<UserWord> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordGroupRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordGroupRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.WordGroup;
@@ -20,7 +21,7 @@ import java.util.Optional;
 public class WordGroupRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(WordGroupRepository.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<WordGroup> table;
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordRepository.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.repository;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
@@ -18,7 +19,7 @@ import java.util.Optional;
 public class WordRepository {
 	
 	private static final Logger logger = LoggerFactory.getLogger(WordRepository.class);
-	private static final String TABLE_NAME = System.getenv("VOCAB_TABLE_NAME");
+	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbEnhancedClient enhancedClient;
 	private final DynamoDbTable<Word> table;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
 import com.mzc.secondproject.serverless.domain.vocabulary.dto.request.SubmitTestRequest;
@@ -26,7 +27,7 @@ import java.util.stream.Collectors;
 public class TestCommandService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(TestCommandService.class);
-	private static final String TEST_RESULT_TOPIC_ARN = System.getenv("TEST_RESULT_TOPIC_ARN");
+	private static final String TEST_RESULT_TOPIC_ARN = EnvConfig.getRequired("TEST_RESULT_TOPIC_ARN");
 	
 	private final TestResultRepository testResultRepository;
 	private final DailyStudyRepository dailyStudyRepository;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestService.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.DailyStudy;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 public class TestService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(TestService.class);
-	private static final String TEST_RESULT_TOPIC_ARN = System.getenv("TEST_RESULT_TOPIC_ARN");
+	private static final String TEST_RESULT_TOPIC_ARN = EnvConfig.getRequired("TEST_RESULT_TOPIC_ARN");
 	
 	private final TestResultRepository testResultRepository;
 	private final DailyStudyRepository dailyStudyRepository;


### PR DESCRIPTION
## Summary
- EnvConfig 유틸리티 클래스 추가로 환경 변수 검증 일원화
- 필수 환경 변수 미설정 시 Lambda Cold Start 시점에 명확한 에러 메시지 제공
- 기존 System.getenv 호출을 EnvConfig로 대체하여 NPE 방지

## Changes
- `EnvConfig.java` 신규: getRequired, getOrDefault, getIntOrDefault, getLongOrDefault 메서드
- Repository/Service/Handler에서 TABLE_NAME, BUCKET_NAME, TOPIC_ARN 등 필수 환경 변수 검증
- WebSocketConfig, RoomTokenConfig를 EnvConfig 사용하도록 리팩토링

## Test
- `./gradlew compileJava` 빌드 성공

Closes #403