### PR TITLE
[MESP-158] TestService submitTest 메서드 리팩토링

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
@@ -92,53 +92,87 @@ public class TestCommandService {
 	
 	public SubmitTestResult submitTest(String userId, String testId, String testType,
 	                                   List<SubmitTestRequest.TestAnswer> answers, String startedAt) {
-		String now = Instant.now().toString();
-		String today = LocalDate.now().toString();
-		
+		// 1. 답안 채점
+		GradingResult gradingResult = gradeAnswers(answers);
+
+		// 2. 테스트 결과 저장
+		TestResult testResult = saveTestResult(userId, testId, testType, gradingResult, startedAt);
+
+		// 3. 오답 단어 자동 북마크
+		bookmarkIncorrectWords(userId, gradingResult.incorrectWordIds());
+
+		// 4. SNS 알림 발행
+		publishTestResultToSns(userId, gradingResult.results());
+
+		logger.info("Test submitted: userId={}, testId={}, successRate={}%",
+				userId, testId, gradingResult.successRate());
+
+		return new SubmitTestResult(
+				testId, testType, gradingResult.totalQuestions(),
+				gradingResult.correctCount(), gradingResult.incorrectCount(),
+				gradingResult.successRate(), gradingResult.results()
+		);
+	}
+
+	private GradingResult gradeAnswers(List<SubmitTestRequest.TestAnswer> answers) {
+		List<String> wordIds = answers.stream()
+				.map(SubmitTestRequest.TestAnswer::getWordId)
+				.collect(Collectors.toList());
+
+		Map<String, Word> wordMap = wordRepository.findByIds(wordIds).stream()
+				.collect(Collectors.toMap(Word::getWordId, w -> w));
+
 		int correctCount = 0;
 		int incorrectCount = 0;
 		List<String> incorrectWordIds = new ArrayList<>();
 		List<Map<String, Object>> results = new ArrayList<>();
-		
-		List<String> wordIds = answers.stream()
-				.map(SubmitTestRequest.TestAnswer::getWordId)
-				.collect(Collectors.toList());
-		List<Word> words = wordRepository.findByIds(wordIds);
-		
-		Map<String, Word> wordMap = words.stream()
-				.collect(Collectors.toMap(Word::getWordId, w -> w));
-		
+
 		for (SubmitTestRequest.TestAnswer answer : answers) {
 			String wordId = answer.getWordId();
 			String userAnswer = answer.getAnswer();
-			
 			Word word = wordMap.get(wordId);
-			if (word != null) {
-				// 빈 답변은 오답 처리
-				boolean isCorrect = userAnswer != null
-						&& !userAnswer.isBlank()
-						&& word.getKorean().trim().equalsIgnoreCase(userAnswer.trim());
-				
-				Map<String, Object> resultItem = new HashMap<>();
-				resultItem.put("wordId", wordId);
-				resultItem.put("english", word.getEnglish());
-				resultItem.put("correctAnswer", word.getKorean());
-				resultItem.put("userAnswer", userAnswer != null ? userAnswer : "");
-				resultItem.put("isCorrect", isCorrect);
-				results.add(resultItem);
-				
-				if (isCorrect) {
-					correctCount++;
-				} else {
-					incorrectCount++;
-					incorrectWordIds.add(wordId);
-				}
+
+			if (word == null) continue;
+
+			boolean isCorrect = isAnswerCorrect(userAnswer, word.getKorean());
+			results.add(buildResultItem(word, userAnswer, isCorrect));
+
+			if (isCorrect) {
+				correctCount++;
+			} else {
+				incorrectCount++;
+				incorrectWordIds.add(wordId);
 			}
 		}
-		
+
 		int totalQuestions = answers.size();
 		double successRate = totalQuestions > 0 ? (correctCount * 100.0 / totalQuestions) : 0;
-		
+
+		return new GradingResult(wordIds, correctCount, incorrectCount, incorrectWordIds,
+				totalQuestions, successRate, results);
+	}
+
+	private boolean isAnswerCorrect(String userAnswer, String correctAnswer) {
+		return userAnswer != null
+				&& !userAnswer.isBlank()
+				&& correctAnswer.trim().equalsIgnoreCase(userAnswer.trim());
+	}
+
+	private Map<String, Object> buildResultItem(Word word, String userAnswer, boolean isCorrect) {
+		Map<String, Object> resultItem = new HashMap<>();
+		resultItem.put("wordId", word.getWordId());
+		resultItem.put("english", word.getEnglish());
+		resultItem.put("correctAnswer", word.getKorean());
+		resultItem.put("userAnswer", userAnswer != null ? userAnswer : "");
+		resultItem.put("isCorrect", isCorrect);
+		return resultItem;
+	}
+
+	private TestResult saveTestResult(String userId, String testId, String testType,
+			GradingResult gradingResult, String startedAt) {
+		String now = Instant.now().toString();
+		String today = LocalDate.now().toString();
+
 		TestResult testResult = TestResult.builder()
 				.pk("TEST#" + userId)
 				.sk("RESULT#" + now)
@@ -147,27 +181,29 @@ public class TestCommandService {
 				.testId(testId)
 				.userId(userId)
 				.testType(testType)
-				.totalQuestions(totalQuestions)
-				.correctAnswers(correctCount)
-				.incorrectAnswers(incorrectCount)
-				.successRate(successRate)
-				.testedWordIds(wordIds)
-				.incorrectWordIds(incorrectWordIds)
+				.totalQuestions(gradingResult.totalQuestions())
+				.correctAnswers(gradingResult.correctCount())
+				.incorrectAnswers(gradingResult.incorrectCount())
+				.successRate(gradingResult.successRate())
+				.testedWordIds(gradingResult.wordIds())
+				.incorrectWordIds(gradingResult.incorrectWordIds())
 				.startedAt(startedAt)
 				.completedAt(now)
 				.build();
-		
+
 		testResultRepository.save(testResult);
-		
-		// 오답 단어 자동 북마크
-		bookmarkIncorrectWords(userId, incorrectWordIds);
-		
-		publishTestResultToSns(userId, results);
-		
-		logger.info("Test submitted: userId={}, testId={}, successRate={}%", userId, testId, successRate);
-		
-		return new SubmitTestResult(testId, testType, totalQuestions, correctCount, incorrectCount, successRate, results);
+		return testResult;
 	}
+
+	private record GradingResult(
+			List<String> wordIds,
+			int correctCount,
+			int incorrectCount,
+			List<String> incorrectWordIds,
+			int totalQuestions,
+			double successRate,
+			List<Map<String, Object>> results
+	) {}
 	
 	private void bookmarkIncorrectWords(String userId, List<String> incorrectWordIds) {
 		if (incorrectWordIds == null || incorrectWordIds.isEmpty()) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestService.java
@@ -85,50 +85,84 @@ public class TestService {
 	
 	public SubmitTestResult submitTest(String userId, String testId, String testType,
 	                                   List<Map<String, Object>> answers, String startedAt) {
-		String now = Instant.now().toString();
-		String today = LocalDate.now().toString();
-		
+		// 1. 답안 채점
+		GradingResult gradingResult = gradeAnswers(answers);
+
+		// 2. 테스트 결과 저장
+		saveTestResult(userId, testId, testType, gradingResult, startedAt);
+
+		// 3. SNS 알림 발행
+		publishTestResultToSns(userId, gradingResult.results());
+
+		logger.info("Test submitted: userId={}, testId={}, successRate={}%",
+				userId, testId, gradingResult.successRate());
+
+		return new SubmitTestResult(
+				testId, testType, gradingResult.totalQuestions(),
+				gradingResult.correctCount(), gradingResult.incorrectCount(),
+				gradingResult.successRate(), gradingResult.results()
+		);
+	}
+
+	private GradingResult gradeAnswers(List<Map<String, Object>> answers) {
+		List<String> wordIds = answers.stream()
+				.map(a -> (String) a.get("wordId"))
+				.collect(Collectors.toList());
+
+		Map<String, Word> wordMap = wordRepository.findByIds(wordIds).stream()
+				.collect(Collectors.toMap(Word::getWordId, w -> w));
+
 		int correctCount = 0;
 		int incorrectCount = 0;
 		List<String> incorrectWordIds = new ArrayList<>();
 		List<Map<String, Object>> results = new ArrayList<>();
-		
-		List<String> wordIds = answers.stream()
-				.map(a -> (String) a.get("wordId"))
-				.collect(Collectors.toList());
-		List<Word> words = wordRepository.findByIds(wordIds);
-		
-		Map<String, Word> wordMap = words.stream()
-				.collect(Collectors.toMap(Word::getWordId, w -> w));
-		
+
 		for (Map<String, Object> answer : answers) {
 			String wordId = (String) answer.get("wordId");
 			String userAnswer = (String) answer.get("answer");
-			
 			Word word = wordMap.get(wordId);
-			if (word != null) {
-				boolean isCorrect = word.getKorean().trim().equalsIgnoreCase(userAnswer.trim());
-				
-				Map<String, Object> resultItem = new HashMap<>();
-				resultItem.put("wordId", wordId);
-				resultItem.put("english", word.getEnglish());
-				resultItem.put("correctAnswer", word.getKorean());
-				resultItem.put("userAnswer", userAnswer);
-				resultItem.put("isCorrect", isCorrect);
-				results.add(resultItem);
-				
-				if (isCorrect) {
-					correctCount++;
-				} else {
-					incorrectCount++;
-					incorrectWordIds.add(wordId);
-				}
+
+			if (word == null) continue;
+
+			boolean isCorrect = isAnswerCorrect(userAnswer, word.getKorean());
+			results.add(buildResultItem(word, userAnswer, isCorrect));
+
+			if (isCorrect) {
+				correctCount++;
+			} else {
+				incorrectCount++;
+				incorrectWordIds.add(wordId);
 			}
 		}
-		
+
 		int totalQuestions = answers.size();
 		double successRate = totalQuestions > 0 ? (correctCount * 100.0 / totalQuestions) : 0;
-		
+
+		return new GradingResult(wordIds, correctCount, incorrectCount, incorrectWordIds,
+				totalQuestions, successRate, results);
+	}
+
+	private boolean isAnswerCorrect(String userAnswer, String correctAnswer) {
+		return userAnswer != null
+				&& !userAnswer.isBlank()
+				&& correctAnswer.trim().equalsIgnoreCase(userAnswer.trim());
+	}
+
+	private Map<String, Object> buildResultItem(Word word, String userAnswer, boolean isCorrect) {
+		Map<String, Object> resultItem = new HashMap<>();
+		resultItem.put("wordId", word.getWordId());
+		resultItem.put("english", word.getEnglish());
+		resultItem.put("correctAnswer", word.getKorean());
+		resultItem.put("userAnswer", userAnswer != null ? userAnswer : "");
+		resultItem.put("isCorrect", isCorrect);
+		return resultItem;
+	}
+
+	private void saveTestResult(String userId, String testId, String testType,
+			GradingResult gradingResult, String startedAt) {
+		String now = Instant.now().toString();
+		String today = LocalDate.now().toString();
+
 		TestResult testResult = TestResult.builder()
 				.pk("TEST#" + userId)
 				.sk("RESULT#" + now)
@@ -137,23 +171,27 @@ public class TestService {
 				.testId(testId)
 				.userId(userId)
 				.testType(testType)
-				.totalQuestions(totalQuestions)
-				.correctAnswers(correctCount)
-				.incorrectAnswers(incorrectCount)
-				.successRate(successRate)
-				.incorrectWordIds(incorrectWordIds)
+				.totalQuestions(gradingResult.totalQuestions())
+				.correctAnswers(gradingResult.correctCount())
+				.incorrectAnswers(gradingResult.incorrectCount())
+				.successRate(gradingResult.successRate())
+				.incorrectWordIds(gradingResult.incorrectWordIds())
 				.startedAt(startedAt)
 				.completedAt(now)
 				.build();
-		
+
 		testResultRepository.save(testResult);
-		
-		publishTestResultToSns(userId, results);
-		
-		logger.info("Test submitted: userId={}, testId={}, successRate={}%", userId, testId, successRate);
-		
-		return new SubmitTestResult(testId, testType, totalQuestions, correctCount, incorrectCount, successRate, results);
 	}
+
+	private record GradingResult(
+			List<String> wordIds,
+			int correctCount,
+			int incorrectCount,
+			List<String> incorrectWordIds,
+			int totalQuestions,
+			double successRate,
+			List<Map<String, Object>> results
+	) {}
 	
 	public PaginatedResult<TestResult> getTestResults(String userId, int limit, String cursor) {
 		return testResultRepository.findByUserIdWithPagination(userId, limit, cursor);


### PR DESCRIPTION
## Summary
- TestService.submitTest() 메서드를 단일 책임 원칙에 맞게 분리
- 가독성과 테스트 용이성 개선

## Changes
### TestCommandService.java
- `gradeAnswers()`: 답안 채점 로직 추출
- `isAnswerCorrect()`: 정답 판정 로직 추출
- `buildResultItem()`: 결과 항목 생성 로직 추출
- `saveTestResult()`: 결과 저장 로직 추출
- `GradingResult` record: 채점 결과 캡슐화

### TestService.java
- 동일한 리팩토링 적용

## Before/After
**Before**: 77줄의 모놀리식 메서드
**After**: 5개의 단일 책임 메서드로 분리

Closes #404