### PR TITLE
[MESP-159] 하드코딩된 설정값 외부화

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/EnvConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/EnvConfig.java
@@ -1,0 +1,94 @@
+package com.mzc.secondproject.serverless.common.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 환경 변수 설정 유틸리티
+ * - 필수 환경 변수 누락 시 명확한 에러 메시지 제공
+ * - Lambda 시작 시 설정 오류를 빠르게 감지
+ */
+public final class EnvConfig {
+
+	private static final Logger logger = LoggerFactory.getLogger(EnvConfig.class);
+
+	private EnvConfig() {
+		// 유틸리티 클래스 - 인스턴스화 방지
+	}
+
+	/**
+	 * 필수 환경 변수를 가져옵니다.
+	 * 환경 변수가 설정되지 않았거나 빈 문자열인 경우 IllegalStateException을 발생시킵니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @return 환경 변수 값
+	 * @throws IllegalStateException 환경 변수가 설정되지 않은 경우
+	 */
+	public static String getRequired(String name) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			String message = String.format("필수 환경 변수 '%s'가 설정되지 않았습니다. SAM template.yaml을 확인하세요.", name);
+			logger.error(message);
+			throw new IllegalStateException(message);
+		}
+		return value;
+	}
+
+	/**
+	 * 선택적 환경 변수를 가져옵니다.
+	 * 환경 변수가 설정되지 않은 경우 기본값을 반환합니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @param defaultValue 기본값
+	 * @return 환경 변수 값 또는 기본값
+	 */
+	public static String getOrDefault(String name, String defaultValue) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			logger.debug("환경 변수 '{}'가 설정되지 않아 기본값 '{}'을 사용합니다.", name, defaultValue);
+			return defaultValue;
+		}
+		return value;
+	}
+
+	/**
+	 * 선택적 환경 변수를 정수로 가져옵니다.
+	 * 환경 변수가 설정되지 않거나 파싱에 실패한 경우 기본값을 반환합니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @param defaultValue 기본값
+	 * @return 환경 변수 값 또는 기본값
+	 */
+	public static int getIntOrDefault(String name, int defaultValue) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			return defaultValue;
+		}
+		try {
+			return Integer.parseInt(value.trim());
+		} catch (NumberFormatException e) {
+			logger.warn("환경 변수 '{}'의 값 '{}'을 정수로 변환할 수 없어 기본값 {}을 사용합니다.", name, value, defaultValue);
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * 선택적 환경 변수를 long으로 가져옵니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @param defaultValue 기본값
+	 * @return 환경 변수 값 또는 기본값
+	 */
+	public static long getLongOrDefault(String name, long defaultValue) {
+		String value = System.getenv(name);
+		if (value == null || value.trim().isEmpty()) {
+			return defaultValue;
+		}
+		try {
+			return Long.parseLong(value.trim());
+		} catch (NumberFormatException e) {
+			logger.warn("환경 변수 '{}'의 값 '{}'을 long으로 변환할 수 없어 기본값 {}을 사용합니다.", name, value, defaultValue);
+			return defaultValue;
+		}
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/config/GameConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/config/GameConfig.java
@@ -1,0 +1,33 @@
+package com.mzc.secondproject.serverless.domain.chatting.config;
+
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+
+/**
+ * 게임 관련 설정값
+ * 환경 변수로 오버라이드 가능
+ */
+public final class GameConfig {
+
+	private static final int DEFAULT_TOTAL_ROUNDS = 5;
+	private static final int DEFAULT_ROUND_TIME_LIMIT = 60;
+	private static final long DEFAULT_QUICK_GUESS_THRESHOLD_MS = 5000L;
+
+	private static final int TOTAL_ROUNDS = EnvConfig.getIntOrDefault("GAME_TOTAL_ROUNDS", DEFAULT_TOTAL_ROUNDS);
+	private static final int ROUND_TIME_LIMIT = EnvConfig.getIntOrDefault("GAME_ROUND_TIME_LIMIT", DEFAULT_ROUND_TIME_LIMIT);
+	private static final long QUICK_GUESS_THRESHOLD_MS = EnvConfig.getLongOrDefault("GAME_QUICK_GUESS_THRESHOLD_MS", DEFAULT_QUICK_GUESS_THRESHOLD_MS);
+
+	private GameConfig() {
+	}
+
+	public static int totalRounds() {
+		return TOTAL_ROUNDS;
+	}
+
+	public static int roundTimeLimit() {
+		return ROUND_TIME_LIMIT;
+	}
+
+	public static long quickGuessThresholdMs() {
+		return QUICK_GUESS_THRESHOLD_MS;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameStatsService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameStatsService.java
@@ -2,6 +2,7 @@ package com.mzc.secondproject.serverless.domain.chatting.service;
 
 import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
 import com.mzc.secondproject.serverless.domain.badge.service.BadgeService;
+import com.mzc.secondproject.serverless.domain.chatting.config.GameConfig;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
 import com.mzc.secondproject.serverless.domain.chatting.model.GameRound;
 import com.mzc.secondproject.serverless.domain.chatting.repository.GameRoundRepository;
@@ -18,7 +19,6 @@ import java.util.*;
 public class GameStatsService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(GameStatsService.class);
-	private static final long QUICK_GUESS_THRESHOLD_MS = 5000; // 5초
 	
 	private final UserStatsRepository userStatsRepository;
 	private final GameRoundRepository gameRoundRepository;
@@ -83,7 +83,7 @@ public class GameStatsService {
 				// 빠른 정답 체크 (5초 이내)
 				if (round.getGuessTimes() != null) {
 					Long guessTime = round.getGuessTimes().get(userId);
-					if (guessTime != null && guessTime <= QUICK_GUESS_THRESHOLD_MS) {
+					if (guessTime != null && guessTime <= GameConfig.quickGuessThresholdMs()) {
 						quickGuesses++;
 					}
 				}
@@ -123,7 +123,7 @@ public class GameStatsService {
 	 * 정답 시 즉시 통계 업데이트 (빠른 정답 뱃지용)
 	 */
 	public List<UserBadge> updateOnCorrectAnswer(String userId, long elapsedTimeMs) {
-		if (elapsedTimeMs > QUICK_GUESS_THRESHOLD_MS) {
+		if (elapsedTimeMs > GameConfig.quickGuessThresholdMs()) {
 			return List.of();
 		}
 		

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/config/GrammarConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/config/GrammarConfig.java
@@ -1,0 +1,39 @@
+package com.mzc.secondproject.serverless.domain.grammar.config;
+
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+
+/**
+ * Grammar 도메인 설정값
+ * 환경 변수로 오버라이드 가능
+ */
+public final class GrammarConfig {
+
+	private static final int DEFAULT_SESSION_TTL_DAYS = 30;
+	private static final int DEFAULT_MAX_HISTORY_MESSAGES = 10;
+	private static final int DEFAULT_LAST_MESSAGE_MAX_LENGTH = 100;
+	private static final int DEFAULT_MAX_TOKENS = 2048;
+
+	private static final int SESSION_TTL_DAYS = EnvConfig.getIntOrDefault("GRAMMAR_SESSION_TTL_DAYS", DEFAULT_SESSION_TTL_DAYS);
+	private static final int MAX_HISTORY_MESSAGES = EnvConfig.getIntOrDefault("GRAMMAR_MAX_HISTORY_MESSAGES", DEFAULT_MAX_HISTORY_MESSAGES);
+	private static final int LAST_MESSAGE_MAX_LENGTH = EnvConfig.getIntOrDefault("GRAMMAR_LAST_MESSAGE_MAX_LENGTH", DEFAULT_LAST_MESSAGE_MAX_LENGTH);
+	private static final int MAX_TOKENS = EnvConfig.getIntOrDefault("GRAMMAR_MAX_TOKENS", DEFAULT_MAX_TOKENS);
+
+	private GrammarConfig() {
+	}
+
+	public static int sessionTtlDays() {
+		return SESSION_TTL_DAYS;
+	}
+
+	public static int maxHistoryMessages() {
+		return MAX_HISTORY_MESSAGES;
+	}
+
+	public static int lastMessageMaxLength() {
+		return LAST_MESSAGE_MAX_LENGTH;
+	}
+
+	public static int maxTokens() {
+		return MAX_TOKENS;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/factory/BedrockGrammarCheckFactory.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/factory/BedrockGrammarCheckFactory.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.domain.grammar.config.GrammarConfig;
 import com.mzc.secondproject.serverless.domain.grammar.dto.response.ConversationResponse;
 import com.mzc.secondproject.serverless.domain.grammar.dto.response.GrammarCheckResponse;
 import com.mzc.secondproject.serverless.domain.grammar.dto.response.GrammarError;
@@ -31,7 +32,6 @@ public class BedrockGrammarCheckFactory implements GrammarCheckFactory {
 	private static final Gson gson = new Gson();
 	
 	private static final String MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0";
-	private static final int MAX_TOKENS = 2048;
 	
 	@Override
 	public GrammarCheckResponse checkGrammar(String sentence, GrammarLevel level) {
@@ -131,7 +131,7 @@ public class BedrockGrammarCheckFactory implements GrammarCheckFactory {
 	private JsonObject buildRequestBody(String userPrompt, String systemPrompt) {
 		JsonObject requestBody = new JsonObject();
 		requestBody.addProperty("anthropic_version", "bedrock-2023-05-31");
-		requestBody.addProperty("max_tokens", MAX_TOKENS);
+		requestBody.addProperty("max_tokens", GrammarConfig.maxTokens());
 		requestBody.addProperty("system", systemPrompt);
 		
 		JsonArray messages = new JsonArray();
@@ -570,7 +570,7 @@ public class BedrockGrammarCheckFactory implements GrammarCheckFactory {
 	private JsonObject buildStreamingRequestBody(String userPrompt, String systemPrompt) {
 		JsonObject requestBody = new JsonObject();
 		requestBody.addProperty("anthropic_version", "bedrock-2023-05-31");
-		requestBody.addProperty("max_tokens", MAX_TOKENS);
+		requestBody.addProperty("max_tokens", GrammarConfig.maxTokens());
 		requestBody.addProperty("system", systemPrompt);
 		// Streaming을 위해 stop_sequences 추가하지 않음
 		

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/config/VocabularyConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/config/VocabularyConfig.java
@@ -1,0 +1,48 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.config;
+
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+
+/**
+ * Vocabulary 도메인 설정값
+ * 환경 변수로 오버라이드 가능
+ */
+public final class VocabularyConfig {
+
+	// 일일 학습 관련
+	private static final int DEFAULT_NEW_WORDS_COUNT = 50;
+	private static final int DEFAULT_REVIEW_WORDS_COUNT = 5;
+
+	// 단어 상태 전이 관련
+	private static final int DEFAULT_TRANSITION_TO_REVIEWING_THRESHOLD = 2;
+	private static final int DEFAULT_TRANSITION_TO_MASTERED_THRESHOLD = 5;
+	private static final int DEFAULT_SECOND_INTERVAL_DAYS = 6;
+
+	private static final int NEW_WORDS_COUNT = EnvConfig.getIntOrDefault("VOCAB_NEW_WORDS_COUNT", DEFAULT_NEW_WORDS_COUNT);
+	private static final int REVIEW_WORDS_COUNT = EnvConfig.getIntOrDefault("VOCAB_REVIEW_WORDS_COUNT", DEFAULT_REVIEW_WORDS_COUNT);
+	private static final int TRANSITION_TO_REVIEWING_THRESHOLD = EnvConfig.getIntOrDefault("VOCAB_TRANSITION_TO_REVIEWING", DEFAULT_TRANSITION_TO_REVIEWING_THRESHOLD);
+	private static final int TRANSITION_TO_MASTERED_THRESHOLD = EnvConfig.getIntOrDefault("VOCAB_TRANSITION_TO_MASTERED", DEFAULT_TRANSITION_TO_MASTERED_THRESHOLD);
+	private static final int SECOND_INTERVAL_DAYS = EnvConfig.getIntOrDefault("VOCAB_SECOND_INTERVAL_DAYS", DEFAULT_SECOND_INTERVAL_DAYS);
+
+	private VocabularyConfig() {
+	}
+
+	public static int newWordsCount() {
+		return NEW_WORDS_COUNT;
+	}
+
+	public static int reviewWordsCount() {
+		return REVIEW_WORDS_COUNT;
+	}
+
+	public static int transitionToReviewingThreshold() {
+		return TRANSITION_TO_REVIEWING_THRESHOLD;
+	}
+
+	public static int transitionToMasteredThreshold() {
+		return TRANSITION_TO_MASTERED_THRESHOLD;
+	}
+
+	public static int secondIntervalDays() {
+		return SECOND_INTERVAL_DAYS;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
@@ -2,6 +2,7 @@ package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.enums.StudyLevel;
+import com.mzc.secondproject.serverless.domain.vocabulary.config.VocabularyConfig;
 import com.mzc.secondproject.serverless.domain.badge.service.BadgeService;
 import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
 import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
@@ -27,9 +28,6 @@ import java.util.stream.Collectors;
 public class DailyStudyCommandService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(DailyStudyCommandService.class);
-	
-	private static final int NEW_WORDS_COUNT = 50;
-	private static final int REVIEW_WORDS_COUNT = 5;
 	
 	private final DailyStudyRepository dailyStudyRepository;
 	private final UserWordRepository userWordRepository;
@@ -116,12 +114,12 @@ public class DailyStudyCommandService {
 	private DailyStudy createDailyStudy(String userId, String date, String level) {
 		String now = Instant.now().toString();
 		
-		PaginatedResult<UserWord> reviewPage = userWordRepository.findReviewDueWords(userId, date, REVIEW_WORDS_COUNT, null);
+		PaginatedResult<UserWord> reviewPage = userWordRepository.findReviewDueWords(userId, date, VocabularyConfig.reviewWordsCount(), null);
 		List<String> reviewWordIds = reviewPage.items().stream()
 				.map(UserWord::getWordId)
 				.collect(Collectors.toList());
 		
-		List<String> newWordIds = getNewWordsForUser(userId, level, NEW_WORDS_COUNT);
+		List<String> newWordIds = getNewWordsForUser(userId, level, VocabularyConfig.newWordsCount());
 		
 		DailyStudy dailyStudy = DailyStudy.builder()
 				.pk(VocabKey.dailyPk(userId))

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyService.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.service;
 
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
+import com.mzc.secondproject.serverless.domain.vocabulary.config.VocabularyConfig;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.DailyStudy;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.UserWord;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
@@ -18,9 +19,6 @@ import java.util.stream.Collectors;
 public class DailyStudyService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(DailyStudyService.class);
-	
-	private static final int NEW_WORDS_COUNT = 50;
-	private static final int REVIEW_WORDS_COUNT = 5;
 	
 	private final DailyStudyRepository dailyStudyRepository;
 	private final UserWordRepository userWordRepository;
@@ -87,12 +85,12 @@ public class DailyStudyService {
 	private DailyStudy createDailyStudy(String userId, String date, String level) {
 		String now = Instant.now().toString();
 		
-		PaginatedResult<UserWord> reviewPage = userWordRepository.findReviewDueWords(userId, date, REVIEW_WORDS_COUNT, null);
+		PaginatedResult<UserWord> reviewPage = userWordRepository.findReviewDueWords(userId, date, VocabularyConfig.reviewWordsCount(), null);
 		List<String> reviewWordIds = reviewPage.items().stream()
 				.map(UserWord::getWordId)
 				.collect(Collectors.toList());
 		
-		List<String> newWordIds = getNewWordsForUser(userId, level, NEW_WORDS_COUNT);
+		List<String> newWordIds = getNewWordsForUser(userId, level, VocabularyConfig.newWordsCount());
 		
 		DailyStudy dailyStudy = DailyStudy.builder()
 				.pk("DAILY#" + userId)

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/state/LearningState.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/state/LearningState.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.state;
 
 import com.mzc.secondproject.serverless.common.config.StudyConfig;
+import com.mzc.secondproject.serverless.domain.vocabulary.config.VocabularyConfig;
 import com.mzc.secondproject.serverless.domain.vocabulary.enums.WordStatus;
 
 /**
@@ -10,8 +11,6 @@ import com.mzc.secondproject.serverless.domain.vocabulary.enums.WordStatus;
 public class LearningState implements WordState {
 	
 	private static final LearningState INSTANCE = new LearningState();
-	private static final int TRANSITION_TO_REVIEWING_THRESHOLD = 2;
-	private static final int SECOND_INTERVAL_DAYS = 6;
 	
 	private LearningState() {
 	}
@@ -29,12 +28,12 @@ public class LearningState implements WordState {
 		if (repetitions == 1) {
 			context.updateInterval(StudyConfig.INITIAL_INTERVAL_DAYS);
 		} else if (repetitions == 2) {
-			context.updateInterval(SECOND_INTERVAL_DAYS);
+			context.updateInterval(VocabularyConfig.secondIntervalDays());
 		} else {
 			context.updateInterval(context.calculateNextInterval());
 		}
 		
-		if (repetitions >= TRANSITION_TO_REVIEWING_THRESHOLD) {
+		if (repetitions >= VocabularyConfig.transitionToReviewingThreshold()) {
 			return ReviewingState.getInstance();
 		}
 		return this;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/state/ReviewingState.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/state/ReviewingState.java
@@ -1,5 +1,6 @@
 package com.mzc.secondproject.serverless.domain.vocabulary.state;
 
+import com.mzc.secondproject.serverless.domain.vocabulary.config.VocabularyConfig;
 import com.mzc.secondproject.serverless.domain.vocabulary.enums.WordStatus;
 
 /**
@@ -9,7 +10,6 @@ import com.mzc.secondproject.serverless.domain.vocabulary.enums.WordStatus;
 public class ReviewingState implements WordState {
 	
 	private static final ReviewingState INSTANCE = new ReviewingState();
-	private static final int TRANSITION_TO_MASTERED_THRESHOLD = 5;
 	
 	private ReviewingState() {
 	}
@@ -24,7 +24,7 @@ public class ReviewingState implements WordState {
 		context.incrementRepetitions();
 		context.updateInterval(context.calculateNextInterval());
 		
-		if (context.getRepetitions() >= TRANSITION_TO_MASTERED_THRESHOLD) {
+		if (context.getRepetitions() >= VocabularyConfig.transitionToMasteredThreshold()) {
 			return MasteredState.getInstance();
 		}
 		return this;


### PR DESCRIPTION
## Summary
- 하드코딩된 설정값들을 환경 변수로 외부화하여 배포 시 유연한 설정 가능
- 도메인별 Config 클래스 생성

## Changes
### 새로 추가된 파일
- `EnvConfig.java`: 환경 변수 유틸리티 (getIntOrDefault, getLongOrDefault 등)
- `GrammarConfig.java`: Grammar 도메인 설정
- `GameConfig.java`: Chatting 게임 관련 설정
- `VocabularyConfig.java`: Vocabulary 도메인 설정

### 지원하는 환경 변수
| 환경 변수 | 기본값 | 설명 |
|-----------|--------|------|
| GRAMMAR_SESSION_TTL_DAYS | 30 | 세션 만료 기간 |
| GRAMMAR_MAX_HISTORY_MESSAGES | 10 | 대화 히스토리 최대 메시지 수 |
| GRAMMAR_MAX_TOKENS | 2048 | Bedrock 응답 최대 토큰 |
| GAME_TOTAL_ROUNDS | 5 | 캐치마인드 총 라운드 수 |
| GAME_ROUND_TIME_LIMIT | 60 | 라운드 제한 시간(초) |
| VOCAB_NEW_WORDS_COUNT | 50 | 일일 신규 단어 수 |
| VOCAB_REVIEW_WORDS_COUNT | 5 | 일일 복습 단어 수 |

Closes #406