### PR TITLE
test: 핵심 서비스 단위 테스트 추가 (#402)

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/dto/response/FeedbackResponse.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/opic/dto/response/FeedbackResponse.java
@@ -11,4 +11,3 @@ public record FeedbackResponse (
         return new FeedbackResponse(List.of(), answer, sampleAnswer);
     }
 }
-가

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/config/EnvConfigSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/config/EnvConfigSpec.groovy
@@ -1,0 +1,133 @@
+package com.mzc.secondproject.serverless.common.config
+
+import spock.lang.Specification
+
+class EnvConfigSpec extends Specification {
+
+    // ==================== getRequired Tests ====================
+
+    def "getRequired: 설정되지 않은 환경 변수에 대해 IllegalStateException 발생"() {
+        when: "존재하지 않는 환경 변수 요청"
+        EnvConfig.getRequired("NON_EXISTENT_ENV_VAR_FOR_TEST_12345")
+
+        then: "IllegalStateException 발생"
+        def e = thrown(IllegalStateException)
+        e.message.contains("NON_EXISTENT_ENV_VAR_FOR_TEST_12345")
+        e.message.contains("설정되지 않았습니다")
+    }
+
+    def "getRequired: 에러 메시지에 SAM template.yaml 언급 포함"() {
+        when:
+        EnvConfig.getRequired("TEST_MISSING_VAR")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains("SAM template.yaml")
+    }
+
+    // ==================== getOrDefault Tests ====================
+
+    def "getOrDefault: 설정되지 않은 환경 변수에 대해 기본값 반환"() {
+        given:
+        def defaultValue = "defaultTestValue"
+
+        when:
+        def result = EnvConfig.getOrDefault("NON_EXISTENT_VAR_TEST", defaultValue)
+
+        then:
+        result == defaultValue
+    }
+
+    def "getOrDefault: PATH 환경 변수가 존재하면 값 반환 (시스템 환경 변수)"() {
+        when: "일반적으로 설정되어 있는 PATH 환경 변수 요청"
+        def result = EnvConfig.getOrDefault("PATH", "default")
+
+        then: "PATH가 설정되어 있으면 해당 값 반환, 아니면 기본값"
+        result != null
+        !result.isEmpty()
+    }
+
+    // ==================== getIntOrDefault Tests ====================
+
+    def "getIntOrDefault: 설정되지 않은 환경 변수에 대해 기본값 반환"() {
+        given:
+        def defaultValue = 42
+
+        when:
+        def result = EnvConfig.getIntOrDefault("NON_EXISTENT_INT_VAR", defaultValue)
+
+        then:
+        result == defaultValue
+    }
+
+    def "getIntOrDefault: 기본값 0 처리"() {
+        when:
+        def result = EnvConfig.getIntOrDefault("NON_EXISTENT_VAR", 0)
+
+        then:
+        result == 0
+    }
+
+    def "getIntOrDefault: 음수 기본값 처리"() {
+        when:
+        def result = EnvConfig.getIntOrDefault("NON_EXISTENT_VAR", -10)
+
+        then:
+        result == -10
+    }
+
+    // ==================== getLongOrDefault Tests ====================
+
+    def "getLongOrDefault: 설정되지 않은 환경 변수에 대해 기본값 반환"() {
+        given:
+        def defaultValue = 1000000000000L
+
+        when:
+        def result = EnvConfig.getLongOrDefault("NON_EXISTENT_LONG_VAR", defaultValue)
+
+        then:
+        result == defaultValue
+    }
+
+    def "getLongOrDefault: 기본값 0L 처리"() {
+        when:
+        def result = EnvConfig.getLongOrDefault("NON_EXISTENT_VAR", 0L)
+
+        then:
+        result == 0L
+    }
+
+    def "getLongOrDefault: 음수 기본값 처리"() {
+        when:
+        def result = EnvConfig.getLongOrDefault("NON_EXISTENT_VAR", -5000L)
+
+        then:
+        result == -5000L
+    }
+
+    // ==================== Edge Cases ====================
+
+    def "getOrDefault: 빈 환경 변수 이름에 대해 기본값 반환"() {
+        when:
+        def result = EnvConfig.getOrDefault("", "default")
+
+        then:
+        result == "default"
+    }
+
+    def "getIntOrDefault: 최대 정수값 기본값 처리"() {
+        when:
+        def result = EnvConfig.getIntOrDefault("NON_EXISTENT", Integer.MAX_VALUE)
+
+        then:
+        result == Integer.MAX_VALUE
+    }
+
+    def "getLongOrDefault: 최대 long값 기본값 처리"() {
+        when:
+        def result = EnvConfig.getLongOrDefault("NON_EXISTENT", Long.MAX_VALUE)
+
+        then:
+        result == Long.MAX_VALUE
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/config/StudyConfigSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/config/StudyConfigSpec.groovy
@@ -1,0 +1,67 @@
+package com.mzc.secondproject.serverless.common.config
+
+import spock.lang.Specification
+
+class StudyConfigSpec extends Specification {
+
+    // ==================== Spaced Repetition Config Tests ====================
+
+    def "Spaced Repetition 기본값 확인"() {
+        expect:
+        StudyConfig.INITIAL_INTERVAL_DAYS == 1
+        StudyConfig.DEFAULT_EASE_FACTOR == 2.5d
+        StudyConfig.MIN_EASE_FACTOR == 1.3d
+        StudyConfig.INITIAL_REPETITIONS == 0
+    }
+
+    def "오답 관련 기본값 확인"() {
+        expect:
+        StudyConfig.MAX_WRONG_COUNT == 3
+    }
+
+    def "테스트 관련 기본값 확인"() {
+        expect:
+        StudyConfig.DEFAULT_WORD_COUNT == 20
+        StudyConfig.DAILY_TEST_WORD_COUNT == 10
+    }
+
+    def "복습 간격 배열 확인"() {
+        expect:
+        StudyConfig.REVIEW_INTERVALS == [1, 3, 7, 14, 30] as int[]
+        StudyConfig.REVIEW_INTERVALS.length == 5
+    }
+
+    def "상태 기본값 확인"() {
+        expect:
+        StudyConfig.DEFAULT_WORD_STATUS == "NEW"
+        StudyConfig.DEFAULT_DIFFICULTY == "NORMAL"
+    }
+
+    def "카운트 초기값 확인"() {
+        expect:
+        StudyConfig.INITIAL_CORRECT_COUNT == 0
+        StudyConfig.INITIAL_INCORRECT_COUNT == 0
+    }
+
+    // ==================== Business Logic Tests ====================
+
+    def "MIN_EASE_FACTOR가 DEFAULT_EASE_FACTOR보다 작음"() {
+        expect:
+        StudyConfig.MIN_EASE_FACTOR < StudyConfig.DEFAULT_EASE_FACTOR
+    }
+
+    def "REVIEW_INTERVALS가 오름차순 정렬"() {
+        given:
+        def intervals = StudyConfig.REVIEW_INTERVALS
+
+        expect: "배열이 오름차순 정렬되어 있음"
+        (0..<intervals.length - 1).every { i ->
+            intervals[i] < intervals[i + 1]
+        }
+    }
+
+    def "DAILY_TEST_WORD_COUNT가 DEFAULT_WORD_COUNT보다 작음"() {
+        expect:
+        StudyConfig.DAILY_TEST_WORD_COUNT <= StudyConfig.DEFAULT_WORD_COUNT
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/dto/PaginatedResultSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/dto/PaginatedResultSpec.groovy
@@ -1,0 +1,70 @@
+package com.mzc.secondproject.serverless.common.dto
+
+import spock.lang.Specification
+
+class PaginatedResultSpec extends Specification {
+
+    def "hasMore: nextCursor가 있으면 true"() {
+        given:
+        def result = new PaginatedResult<String>(["item1", "item2"], "cursor123")
+
+        expect:
+        result.hasMore() == true
+    }
+
+    def "hasMore: nextCursor가 null이면 false"() {
+        given:
+        def result = new PaginatedResult<String>(["item1", "item2"], null)
+
+        expect:
+        result.hasMore() == false
+    }
+
+    def "items: 아이템 목록 반환"() {
+        given:
+        def items = ["apple", "banana", "cherry"]
+        def result = new PaginatedResult<String>(items, "cursor")
+
+        expect:
+        result.items() == items
+        result.items().size() == 3
+    }
+
+    def "nextCursor: 커서 값 반환"() {
+        given:
+        def cursor = "abc123"
+        def result = new PaginatedResult<String>([], cursor)
+
+        expect:
+        result.nextCursor() == cursor
+    }
+
+    def "빈 아이템 목록 처리"() {
+        given:
+        def result = new PaginatedResult<String>([], null)
+
+        expect:
+        result.items().isEmpty()
+        !result.hasMore()
+    }
+
+    def "제네릭 타입으로 Integer 사용"() {
+        given:
+        def items = [1, 2, 3, 4, 5]
+        def result = new PaginatedResult<Integer>(items, "next")
+
+        expect:
+        result.items() == [1, 2, 3, 4, 5]
+        result.hasMore()
+    }
+
+    def "제네릭 타입으로 커스텀 객체 사용"() {
+        given:
+        def items = [[name: "test1"], [name: "test2"]]
+        def result = new PaginatedResult<Map>(items, null)
+
+        expect:
+        result.items().size() == 2
+        !result.hasMore()
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/enums/DifficultySpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/enums/DifficultySpec.groovy
@@ -1,0 +1,100 @@
+package com.mzc.secondproject.serverless.common.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DifficultySpec extends Specification {
+
+    // ==================== isValid Tests ====================
+
+    @Unroll
+    def "isValid: '#value' -> #expected"() {
+        expect: "유효성 검사 결과가 예상과 일치"
+        Difficulty.isValid(value) == expected
+
+        where:
+        value     | expected
+        "EASY"    | true
+        "NORMAL"  | true
+        "HARD"    | true
+        "easy"    | true
+        "normal"  | true
+        "hard"    | true
+        "Easy"    | true
+        "Normal"  | true
+        "Hard"    | true
+        "INVALID" | false
+        ""        | false
+        null      | false
+    }
+
+    // ==================== fromString Tests ====================
+
+    @Unroll
+    def "fromString: '#value' -> #expected"() {
+        when: "문자열로부터 Difficulty 변환"
+        def result = Difficulty.fromString(value)
+
+        then: "올바른 Difficulty 반환"
+        result == expected
+
+        where:
+        value    | expected
+        "EASY"   | Difficulty.EASY
+        "easy"   | Difficulty.EASY
+        "NORMAL" | Difficulty.NORMAL
+        "normal" | Difficulty.NORMAL
+        "HARD"   | Difficulty.HARD
+        "hard"   | Difficulty.HARD
+    }
+
+    def "fromString: null 입력 시 IllegalArgumentException 발생"() {
+        when: "null로 변환 시도"
+        Difficulty.fromString(null)
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    def "fromString: 잘못된 값 입력 시 IllegalArgumentException 발생"() {
+        when: "잘못된 값으로 변환 시도"
+        Difficulty.fromString("VERY_HARD")
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    // ==================== fromStringOrDefault Tests ====================
+
+    @Unroll
+    def "fromStringOrDefault: '#value' with default #defaultValue -> #expected"() {
+        expect: "기본값 처리 정상 동작"
+        Difficulty.fromStringOrDefault(value, defaultValue) == expected
+
+        where:
+        value     | defaultValue      | expected
+        "EASY"    | Difficulty.HARD   | Difficulty.EASY
+        null      | Difficulty.NORMAL | Difficulty.NORMAL
+        "INVALID" | Difficulty.EASY   | Difficulty.EASY
+        ""        | Difficulty.HARD   | Difficulty.HARD
+    }
+
+    // ==================== Getter Tests ====================
+
+    def "Difficulty 속성 정상 반환"() {
+        expect: "각 난이도의 code와 displayName 확인"
+        Difficulty.EASY.getCode() == "easy"
+        Difficulty.EASY.getDisplayName() == "쉬움"
+
+        Difficulty.NORMAL.getCode() == "normal"
+        Difficulty.NORMAL.getDisplayName() == "보통"
+
+        Difficulty.HARD.getCode() == "hard"
+        Difficulty.HARD.getDisplayName() == "어려움"
+    }
+
+    def "모든 Difficulty 값 존재 확인"() {
+        expect: "3개의 난이도 존재"
+        Difficulty.values().length == 3
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/enums/StudyLevelSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/enums/StudyLevelSpec.groovy
@@ -1,0 +1,96 @@
+package com.mzc.secondproject.serverless.common.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class StudyLevelSpec extends Specification {
+
+    // ==================== isValid Tests ====================
+
+    @Unroll
+    def "isValid: '#value' -> #expected"() {
+        expect: "유효성 검사 결과가 예상과 일치"
+        StudyLevel.isValid(value) == expected
+
+        where:
+        value          | expected
+        "BEGINNER"     | true
+        "INTERMEDIATE" | true
+        "ADVANCED"     | true
+        "beginner"     | true
+        "Beginner"     | true
+        "INVALID"      | false
+        ""             | false
+        null           | false
+    }
+
+    // ==================== fromString Tests ====================
+
+    @Unroll
+    def "fromString: '#value' -> #expected"() {
+        when: "문자열로부터 StudyLevel 변환"
+        def result = StudyLevel.fromString(value)
+
+        then: "올바른 StudyLevel 반환"
+        result == expected
+
+        where:
+        value          | expected
+        "BEGINNER"     | StudyLevel.BEGINNER
+        "beginner"     | StudyLevel.BEGINNER
+        "INTERMEDIATE" | StudyLevel.INTERMEDIATE
+        "intermediate" | StudyLevel.INTERMEDIATE
+        "ADVANCED"     | StudyLevel.ADVANCED
+        "advanced"     | StudyLevel.ADVANCED
+    }
+
+    def "fromString: null 입력 시 IllegalArgumentException 발생"() {
+        when: "null로 변환 시도"
+        StudyLevel.fromString(null)
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    def "fromString: 잘못된 값 입력 시 IllegalArgumentException 발생"() {
+        when: "잘못된 값으로 변환 시도"
+        StudyLevel.fromString("INVALID")
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    // ==================== fromStringOrDefault Tests ====================
+
+    @Unroll
+    def "fromStringOrDefault: '#value' with default #defaultValue -> #expected"() {
+        expect: "기본값 처리 정상 동작"
+        StudyLevel.fromStringOrDefault(value, defaultValue) == expected
+
+        where:
+        value      | defaultValue            | expected
+        "BEGINNER" | StudyLevel.ADVANCED     | StudyLevel.BEGINNER
+        null       | StudyLevel.INTERMEDIATE | StudyLevel.INTERMEDIATE
+        "INVALID"  | StudyLevel.BEGINNER     | StudyLevel.BEGINNER
+        ""         | StudyLevel.ADVANCED     | StudyLevel.ADVANCED
+    }
+
+    // ==================== Getter Tests ====================
+
+    def "StudyLevel 속성 정상 반환"() {
+        expect: "각 레벨의 code와 displayName 확인"
+        StudyLevel.BEGINNER.getCode() == "beginner"
+        StudyLevel.BEGINNER.getDisplayName() == "초급"
+
+        StudyLevel.INTERMEDIATE.getCode() == "intermediate"
+        StudyLevel.INTERMEDIATE.getDisplayName() == "중급"
+
+        StudyLevel.ADVANCED.getCode() == "advanced"
+        StudyLevel.ADVANCED.getDisplayName() == "고급"
+    }
+
+    def "모든 StudyLevel 값 존재 확인"() {
+        expect: "3개의 레벨 존재"
+        StudyLevel.values().length == 3
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/exception/CommonErrorCodeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/exception/CommonErrorCodeSpec.groovy
@@ -1,0 +1,79 @@
+package com.mzc.secondproject.serverless.common.exception
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CommonErrorCodeSpec extends Specification {
+
+    @Unroll
+    def "에러 코드 '#errorCode': code=#expectedCode, statusCode=#expectedStatusCode"() {
+        expect:
+        errorCode.getCode() == expectedCode
+        errorCode.getStatusCode() == expectedStatusCode
+        errorCode.getMessage() != null
+        !errorCode.getMessage().isEmpty()
+
+        where:
+        errorCode                                   | expectedCode       | expectedStatusCode
+        CommonErrorCode.UNAUTHORIZED                | "AUTH_001"         | 401
+        CommonErrorCode.FORBIDDEN                   | "AUTH_002"         | 403
+        CommonErrorCode.INVALID_TOKEN               | "AUTH_003"         | 401
+        CommonErrorCode.TOKEN_EXPIRED               | "AUTH_004"         | 401
+        CommonErrorCode.INVALID_INPUT               | "VALIDATION_001"   | 400
+        CommonErrorCode.REQUIRED_FIELD_MISSING      | "VALIDATION_002"   | 400
+        CommonErrorCode.INVALID_FORMAT              | "VALIDATION_003"   | 400
+        CommonErrorCode.VALUE_OUT_OF_RANGE          | "VALIDATION_004"   | 400
+        CommonErrorCode.RESOURCE_NOT_FOUND          | "RESOURCE_001"     | 404
+        CommonErrorCode.METHOD_NOT_ALLOWED          | "RESOURCE_003"     | 405
+        CommonErrorCode.RESOURCE_ALREADY_EXISTS     | "RESOURCE_002"     | 409
+        CommonErrorCode.INTERNAL_SERVER_ERROR       | "SYSTEM_001"       | 500
+        CommonErrorCode.DATABASE_ERROR              | "SYSTEM_002"       | 500
+        CommonErrorCode.EXTERNAL_API_ERROR          | "SYSTEM_003"       | 502
+        CommonErrorCode.SERVICE_UNAVAILABLE         | "SYSTEM_004"       | 503
+    }
+
+    def "인증 관련 에러 코드들은 4xx"() {
+        expect:
+        CommonErrorCode.UNAUTHORIZED.getStatusCode() == 401
+        CommonErrorCode.FORBIDDEN.getStatusCode() == 403
+        CommonErrorCode.INVALID_TOKEN.getStatusCode() == 401
+        CommonErrorCode.TOKEN_EXPIRED.getStatusCode() == 401
+    }
+
+    def "검증 관련 에러 코드들은 400"() {
+        expect:
+        CommonErrorCode.INVALID_INPUT.getStatusCode() == 400
+        CommonErrorCode.REQUIRED_FIELD_MISSING.getStatusCode() == 400
+        CommonErrorCode.INVALID_FORMAT.getStatusCode() == 400
+        CommonErrorCode.VALUE_OUT_OF_RANGE.getStatusCode() == 400
+    }
+
+    def "시스템 에러 코드들은 5xx"() {
+        expect:
+        CommonErrorCode.INTERNAL_SERVER_ERROR.getStatusCode() == 500
+        CommonErrorCode.DATABASE_ERROR.getStatusCode() == 500
+        CommonErrorCode.EXTERNAL_API_ERROR.getStatusCode() == 502
+        CommonErrorCode.SERVICE_UNAVAILABLE.getStatusCode() == 503
+    }
+
+    def "isClientError: 4xx 상태 코드"() {
+        expect:
+        CommonErrorCode.UNAUTHORIZED.isClientError()
+        CommonErrorCode.FORBIDDEN.isClientError()
+        CommonErrorCode.INVALID_INPUT.isClientError()
+        CommonErrorCode.RESOURCE_NOT_FOUND.isClientError()
+    }
+
+    def "isServerError: 5xx 상태 코드"() {
+        expect:
+        CommonErrorCode.INTERNAL_SERVER_ERROR.isServerError()
+        CommonErrorCode.DATABASE_ERROR.isServerError()
+        CommonErrorCode.EXTERNAL_API_ERROR.isServerError()
+        CommonErrorCode.SERVICE_UNAVAILABLE.isServerError()
+    }
+
+    def "모든 에러 코드 개수 확인"() {
+        expect: "15개의 에러 코드 존재"
+        CommonErrorCode.values().length == 15
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/exception/CommonExceptionSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/exception/CommonExceptionSpec.groovy
@@ -1,0 +1,236 @@
+package com.mzc.secondproject.serverless.common.exception
+
+import spock.lang.Specification
+
+class CommonExceptionSpec extends Specification {
+
+    // ==================== 인증/인가 예외 Tests ====================
+
+    def "unauthorized: 기본 메시지와 401 상태 코드"() {
+        when:
+        def exception = CommonException.unauthorized()
+
+        then:
+        exception.getErrorCode() == CommonErrorCode.UNAUTHORIZED
+        exception.getStatusCode() == 401
+        exception.isClientError()
+    }
+
+    def "unauthorized: 커스텀 메시지"() {
+        given:
+        def message = "로그인이 필요한 서비스입니다"
+
+        when:
+        def exception = CommonException.unauthorized(message)
+
+        then:
+        exception.getMessage() == message
+        exception.getStatusCode() == 401
+    }
+
+    def "forbidden: 기본 메시지와 403 상태 코드"() {
+        when:
+        def exception = CommonException.forbidden()
+
+        then:
+        exception.getErrorCode() == CommonErrorCode.FORBIDDEN
+        exception.getStatusCode() == 403
+    }
+
+    def "forbidden: 리소스 이름 포함"() {
+        when:
+        def exception = CommonException.forbidden("관리자 페이지")
+
+        then:
+        exception.getMessage().contains("관리자 페이지")
+        exception.getStatusCode() == 403
+    }
+
+    def "invalidToken: 401 상태 코드"() {
+        when:
+        def exception = CommonException.invalidToken()
+
+        then:
+        exception.getErrorCode() == CommonErrorCode.INVALID_TOKEN
+        exception.getStatusCode() == 401
+    }
+
+    def "tokenExpired: 401 상태 코드"() {
+        when:
+        def exception = CommonException.tokenExpired()
+
+        then:
+        exception.getErrorCode() == CommonErrorCode.TOKEN_EXPIRED
+        exception.getStatusCode() == 401
+    }
+
+    // ==================== 검증 예외 Tests ====================
+
+    def "invalidInput: 기본 메시지와 400 상태 코드"() {
+        when:
+        def exception = CommonException.invalidInput()
+
+        then:
+        exception.getErrorCode() == CommonErrorCode.INVALID_INPUT
+        exception.getStatusCode() == 400
+    }
+
+    def "invalidInput: 커스텀 메시지"() {
+        given:
+        def message = "이메일 형식이 올바르지 않습니다"
+
+        when:
+        def exception = CommonException.invalidInput(message)
+
+        then:
+        exception.getMessage() == message
+    }
+
+    def "requiredFieldMissing: 필드명 포함"() {
+        when:
+        def exception = CommonException.requiredFieldMissing("email")
+
+        then:
+        exception.getMessage().contains("email")
+        exception.getStatusCode() == 400
+    }
+
+    def "invalidFormat: 필드명 포함"() {
+        when:
+        def exception = CommonException.invalidFormat("phoneNumber")
+
+        then:
+        exception.getMessage().contains("phoneNumber")
+        exception.getStatusCode() == 400
+    }
+
+    def "valueOutOfRange: 필드명과 범위 포함"() {
+        when:
+        def exception = CommonException.valueOutOfRange("age", 1, 120)
+
+        then:
+        exception.getMessage().contains("age")
+        exception.getMessage().contains("1")
+        exception.getMessage().contains("120")
+        exception.getStatusCode() == 400
+    }
+
+    // ==================== 리소스 예외 Tests ====================
+
+    def "notFound: 리소스명 포함"() {
+        when:
+        def exception = CommonException.notFound("사용자")
+
+        then:
+        exception.getMessage().contains("사용자")
+        exception.getStatusCode() == 404
+    }
+
+    def "notFound: 리소스명과 ID 포함"() {
+        when:
+        def exception = CommonException.notFound("사용자", "user123")
+
+        then:
+        exception.getMessage().contains("사용자")
+        exception.getMessage().contains("user123")
+        exception.getStatusCode() == 404
+    }
+
+    def "alreadyExists: 리소스명 포함"() {
+        when:
+        def exception = CommonException.alreadyExists("이메일")
+
+        then:
+        exception.getMessage().contains("이메일")
+        exception.getStatusCode() == 409
+    }
+
+    def "alreadyExists: 리소스명과 ID 포함"() {
+        when:
+        def exception = CommonException.alreadyExists("사용자", "user@test.com")
+
+        then:
+        exception.getMessage().contains("사용자")
+        exception.getMessage().contains("user@test.com")
+        exception.getStatusCode() == 409
+    }
+
+    // ==================== 시스템 예외 Tests ====================
+
+    def "internalError: 기본 메시지와 500 상태 코드"() {
+        when:
+        def exception = CommonException.internalError()
+
+        then:
+        exception.getErrorCode() == CommonErrorCode.INTERNAL_SERVER_ERROR
+        exception.getStatusCode() == 500
+        exception.isServerError()
+    }
+
+    def "internalError: Throwable cause 포함"() {
+        given:
+        def cause = new RuntimeException("Original error")
+
+        when:
+        def exception = CommonException.internalError(cause)
+
+        then:
+        exception.getCause() == cause
+        exception.getStatusCode() == 500
+    }
+
+    def "internalError: 커스텀 메시지"() {
+        given:
+        def message = "데이터 처리 중 오류"
+
+        when:
+        def exception = CommonException.internalError(message)
+
+        then:
+        exception.getMessage() == message
+        exception.getStatusCode() == 500
+    }
+
+    def "databaseError: cause 포함"() {
+        given:
+        def cause = new RuntimeException("DB connection failed")
+
+        when:
+        def exception = CommonException.databaseError(cause)
+
+        then:
+        exception.getCause() == cause
+        exception.getStatusCode() == 500
+    }
+
+    def "externalApiError: API 이름 포함"() {
+        when:
+        def exception = CommonException.externalApiError("OpenAI API")
+
+        then:
+        exception.getMessage().contains("OpenAI API")
+        exception.getStatusCode() == 502
+    }
+
+    def "externalApiError: API 이름과 cause 포함"() {
+        given:
+        def cause = new RuntimeException("Connection timeout")
+
+        when:
+        def exception = CommonException.externalApiError("Bedrock API", cause)
+
+        then:
+        exception.getMessage().contains("Bedrock API")
+        exception.getCause() == cause
+        exception.getStatusCode() == 502
+    }
+
+    def "serviceUnavailable: 503 상태 코드"() {
+        when:
+        def exception = CommonException.serviceUnavailable()
+
+        then:
+        exception.getErrorCode() == CommonErrorCode.SERVICE_UNAVAILABLE
+        exception.getStatusCode() == 503
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/util/CursorUtilSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/util/CursorUtilSpec.groovy
@@ -1,0 +1,98 @@
+package com.mzc.secondproject.serverless.common.util
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import spock.lang.Specification
+
+class CursorUtilSpec extends Specification {
+
+    // ==================== encode Tests ====================
+
+    def "encode: 정상적인 lastEvaluatedKey 인코딩"() {
+        given: "PK, SK가 있는 lastEvaluatedKey"
+        def lastEvaluatedKey = [
+                "PK": AttributeValue.builder().s("USER#user123").build(),
+                "SK": AttributeValue.builder().s("WORD#word456").build()
+        ]
+
+        when: "인코딩"
+        def cursor = CursorUtil.encode(lastEvaluatedKey)
+
+        then: "Base64 인코딩된 커서 반환"
+        cursor != null
+        !cursor.isEmpty()
+    }
+
+    def "encode: null 입력"() {
+        when:
+        def cursor = CursorUtil.encode(null)
+
+        then:
+        cursor == null
+    }
+
+    def "encode: 빈 Map 입력"() {
+        when:
+        def cursor = CursorUtil.encode([:])
+
+        then:
+        cursor == null
+    }
+
+    // ==================== decode Tests ====================
+
+    def "encode-decode 왕복 테스트"() {
+        given: "원본 lastEvaluatedKey"
+        def original = [
+                "PK": AttributeValue.builder().s("USER#testUser").build(),
+                "SK": AttributeValue.builder().s("DATE#2026-01-20").build()
+        ]
+
+        when: "인코딩 후 디코딩"
+        def cursor = CursorUtil.encode(original)
+        def decoded = CursorUtil.decode(cursor)
+
+        then: "원본과 동일한 키-값 복원"
+        decoded != null
+        decoded["PK"].s() == "USER#testUser"
+        decoded["SK"].s() == "DATE#2026-01-20"
+    }
+
+    def "decode: null 입력"() {
+        when:
+        def result = CursorUtil.decode(null)
+
+        then:
+        result == null
+    }
+
+    def "decode: 빈 문자열 입력"() {
+        when:
+        def result = CursorUtil.decode("")
+
+        then:
+        result == null
+    }
+
+    def "decode: 잘못된 Base64 문자열"() {
+        when:
+        def result = CursorUtil.decode("not-valid-base64!!!")
+
+        then: "예외 발생하지 않고 null 반환"
+        result == null
+    }
+
+    def "encode: 단일 키-값 쌍"() {
+        given:
+        def lastEvaluatedKey = [
+                "PK": AttributeValue.builder().s("SINGLE#key").build()
+        ]
+
+        when:
+        def cursor = CursorUtil.encode(lastEvaluatedKey)
+        def decoded = CursorUtil.decode(cursor)
+
+        then:
+        decoded != null
+        decoded["PK"].s() == "SINGLE#key"
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/util/JsonUtilSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/common/util/JsonUtilSpec.groovy
@@ -1,0 +1,122 @@
+package com.mzc.secondproject.serverless.common.util
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonParser
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JsonUtilSpec extends Specification {
+
+    // ==================== extractJson Tests ====================
+
+    def "extractJson: 정상적인 JSON 객체 추출"() {
+        given:
+        def response = 'Some text before {"key": "value"} and after'
+
+        when:
+        def result = JsonUtil.extractJson(response)
+
+        then:
+        result == '{"key": "value"}'
+    }
+
+    def "extractJson: 중첩된 JSON 객체 추출"() {
+        given:
+        def response = 'Prefix {"outer": {"inner": "value"}} Suffix'
+
+        when:
+        def result = JsonUtil.extractJson(response)
+
+        then:
+        result == '{"outer": {"inner": "value"}}'
+    }
+
+    def "extractJson: 순수 JSON 문자열"() {
+        given:
+        def response = '{"name": "test", "count": 10}'
+
+        when:
+        def result = JsonUtil.extractJson(response)
+
+        then:
+        result == '{"name": "test", "count": 10}'
+    }
+
+    def "extractJson: null 입력"() {
+        when:
+        def result = JsonUtil.extractJson(null)
+
+        then:
+        result == null
+    }
+
+    def "extractJson: 빈 문자열 입력"() {
+        when:
+        def result = JsonUtil.extractJson("")
+
+        then:
+        result == null
+    }
+
+    def "extractJson: 공백만 있는 문자열 입력"() {
+        when:
+        def result = JsonUtil.extractJson("   ")
+
+        then:
+        result == null
+    }
+
+    def "extractJson: JSON이 없는 문자열"() {
+        given:
+        def response = "This is plain text without JSON"
+
+        when:
+        def result = JsonUtil.extractJson(response)
+
+        then:
+        result == response  // 원본 반환
+    }
+
+    // ==================== toStringList Tests ====================
+
+    def "toStringList: 정상적인 JsonArray 변환"() {
+        given:
+        def jsonArray = JsonParser.parseString('["apple", "banana", "cherry"]').getAsJsonArray()
+
+        when:
+        def result = JsonUtil.toStringList(jsonArray)
+
+        then:
+        result == ["apple", "banana", "cherry"]
+    }
+
+    def "toStringList: 빈 JsonArray 변환"() {
+        given:
+        def jsonArray = new JsonArray()
+
+        when:
+        def result = JsonUtil.toStringList(jsonArray)
+
+        then:
+        result == []
+    }
+
+    def "toStringList: null 입력"() {
+        when:
+        def result = JsonUtil.toStringList(null)
+
+        then:
+        result == []
+    }
+
+    def "toStringList: 단일 요소 JsonArray"() {
+        given:
+        def jsonArray = JsonParser.parseString('["single"]').getAsJsonArray()
+
+        when:
+        def result = JsonUtil.toStringList(jsonArray)
+
+        then:
+        result == ["single"]
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/badge/constants/BadgeKeySpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/badge/constants/BadgeKeySpec.groovy
@@ -1,0 +1,47 @@
+package com.mzc.secondproject.serverless.domain.badge.constants
+
+import spock.lang.Specification
+
+class BadgeKeySpec extends Specification {
+
+    // ==================== Key Builder Tests ====================
+
+    def "userBadgePk: USER#userId#BADGE 형식"() {
+        expect:
+        BadgeKey.userBadgePk("user123") == "USER#user123#BADGE"
+        BadgeKey.userBadgePk("testUser") == "USER#testUser#BADGE"
+    }
+
+    def "badgeSk: BADGE#badgeType 형식"() {
+        expect:
+        BadgeKey.badgeSk("FIRST_STEP") == "BADGE#FIRST_STEP"
+        BadgeKey.badgeSk("STREAK_7") == "BADGE#STREAK_7"
+        BadgeKey.badgeSk("WORDS_100") == "BADGE#WORDS_100"
+    }
+
+    def "earnedSk: EARNED#earnedAt 형식"() {
+        expect:
+        BadgeKey.earnedSk("2026-01-20T10:30:00Z") == "EARNED#2026-01-20T10:30:00Z"
+    }
+
+    // ==================== Constants Tests ====================
+
+    def "BADGE_ALL 상수값 확인"() {
+        expect:
+        BadgeKey.BADGE_ALL == "BADGE#ALL"
+    }
+
+    // ==================== Consistency Tests ====================
+
+    def "동일한 입력에 대해 동일한 키 생성"() {
+        given:
+        def userId = "consistentUser"
+
+        when:
+        def key1 = BadgeKey.userBadgePk(userId)
+        def key2 = BadgeKey.userBadgePk(userId)
+
+        then:
+        key1 == key2
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/badge/enums/BadgeTypeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/badge/enums/BadgeTypeSpec.groovy
@@ -1,0 +1,124 @@
+package com.mzc.secondproject.serverless.domain.badge.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BadgeTypeSpec extends Specification {
+
+    // ==================== fromString Tests ====================
+
+    @Unroll
+    def "fromString: '#value' -> #expected"() {
+        expect: "문자열로부터 BadgeType 변환"
+        BadgeType.fromString(value) == expected
+
+        where:
+        value         | expected
+        "FIRST_STEP"  | BadgeType.FIRST_STEP
+        "first_step"  | BadgeType.FIRST_STEP
+        "First_Step"  | BadgeType.FIRST_STEP
+        "STREAK_3"    | BadgeType.STREAK_3
+        "STREAK_7"    | BadgeType.STREAK_7
+        "STREAK_30"   | BadgeType.STREAK_30
+        "WORDS_100"   | BadgeType.WORDS_100
+        "WORDS_500"   | BadgeType.WORDS_500
+        "WORDS_1000"  | BadgeType.WORDS_1000
+        null          | null
+        "INVALID"     | null
+        ""            | null
+    }
+
+    // ==================== Category Tests ====================
+
+    @Unroll
+    def "Badge '#badge.name()' 카테고리 '#badge.getCategory()' 확인"() {
+        expect: "카테고리별 뱃지 분류 확인"
+        badge.getCategory() == expectedCategory
+
+        where:
+        badge                       | expectedCategory
+        BadgeType.FIRST_STEP        | "FIRST_STUDY"
+        BadgeType.STREAK_3          | "STREAK"
+        BadgeType.STREAK_7          | "STREAK"
+        BadgeType.STREAK_30         | "STREAK"
+        BadgeType.WORDS_100         | "WORDS_LEARNED"
+        BadgeType.WORDS_500         | "WORDS_LEARNED"
+        BadgeType.WORDS_1000        | "WORDS_LEARNED"
+        BadgeType.PERFECT_SCORE     | "PERFECT_TEST"
+        BadgeType.TEST_10           | "TESTS_COMPLETED"
+        BadgeType.ACCURACY_90       | "ACCURACY"
+        BadgeType.GAME_FIRST_PLAY   | "GAMES_PLAYED"
+        BadgeType.GAME_10_WINS      | "GAMES_WON"
+        BadgeType.QUICK_GUESSER     | "QUICK_GUESSES"
+        BadgeType.PERFECT_DRAWER    | "PERFECT_DRAWS"
+        BadgeType.MASTER            | "ALL_BADGES"
+    }
+
+    // ==================== Threshold Tests ====================
+
+    @Unroll
+    def "Badge '#badge.name()' threshold #badge.getThreshold() 확인"() {
+        expect: "임계값 확인"
+        badge.getThreshold() == expectedThreshold
+
+        where:
+        badge                       | expectedThreshold
+        BadgeType.FIRST_STEP        | 1
+        BadgeType.STREAK_3          | 3
+        BadgeType.STREAK_7          | 7
+        BadgeType.STREAK_30         | 30
+        BadgeType.WORDS_100         | 100
+        BadgeType.WORDS_500         | 500
+        BadgeType.WORDS_1000        | 1000
+        BadgeType.TEST_10           | 10
+        BadgeType.ACCURACY_90       | 90
+        BadgeType.GAME_10_WINS      | 10
+    }
+
+    // ==================== Property Tests ====================
+
+    def "FIRST_STEP 뱃지 속성 확인"() {
+        given:
+        def badge = BadgeType.FIRST_STEP
+
+        expect:
+        badge.getName() == "첫 걸음"
+        badge.getDescription() == "첫 학습을 완료했습니다"
+        badge.getImageFile() == "first_step.png"
+        badge.getImageUrl().contains("first_step.png")
+    }
+
+    def "STREAK 뱃지 속성 확인"() {
+        expect:
+        BadgeType.STREAK_3.getName() == "3일 연속 학습"
+        BadgeType.STREAK_7.getName() == "일주일 연속 학습"
+        BadgeType.STREAK_30.getName() == "한 달 연속 학습"
+    }
+
+    def "WORDS 뱃지 속성 확인"() {
+        expect:
+        BadgeType.WORDS_100.getName() == "단어 수집가"
+        BadgeType.WORDS_500.getName() == "단어 전문가"
+        BadgeType.WORDS_1000.getName() == "단어 마스터"
+    }
+
+    def "게임 관련 뱃지 속성 확인"() {
+        expect:
+        BadgeType.GAME_FIRST_PLAY.getName() == "첫 게임"
+        BadgeType.GAME_10_WINS.getName() == "게임 10승"
+        BadgeType.QUICK_GUESSER.getName() == "번개 정답"
+        BadgeType.PERFECT_DRAWER.getName() == "완벽한 출제자"
+    }
+
+    def "모든 BadgeType 개수 확인"() {
+        expect: "15개의 뱃지 타입 존재"
+        BadgeType.values().length == 15
+    }
+
+    def "모든 뱃지의 imageUrl이 S3 URL 형식"() {
+        expect: "모든 뱃지 이미지 URL이 S3 경로 포함"
+        BadgeType.values().every { badge ->
+            badge.getImageUrl().contains("s3.ap-northeast-2.amazonaws.com")
+        }
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/config/GameConfigSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/config/GameConfigSpec.groovy
@@ -1,0 +1,47 @@
+package com.mzc.secondproject.serverless.domain.chatting.config
+
+import spock.lang.Specification
+
+class GameConfigSpec extends Specification {
+
+    def "totalRounds 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        GameConfig.totalRounds() > 0
+    }
+
+    def "roundTimeLimit 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        GameConfig.roundTimeLimit() > 0
+    }
+
+    def "quickGuessThresholdMs 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        GameConfig.quickGuessThresholdMs() > 0
+    }
+
+    // ==================== Business Logic Tests ====================
+
+    def "모든 설정값이 양수"() {
+        expect:
+        GameConfig.totalRounds() > 0
+        GameConfig.roundTimeLimit() > 0
+        GameConfig.quickGuessThresholdMs() > 0
+    }
+
+    def "quickGuessThresholdMs가 roundTimeLimit보다 작음"() {
+        expect: "빠른 추측 임계값(ms)이 라운드 시간 제한(초)을 ms로 변환한 값보다 작아야 함"
+        GameConfig.quickGuessThresholdMs() < GameConfig.roundTimeLimit() * 1000L
+    }
+
+    def "totalRounds가 합리적인 범위"() {
+        expect: "라운드 수는 1~20 범위"
+        GameConfig.totalRounds() >= 1
+        GameConfig.totalRounds() <= 20
+    }
+
+    def "roundTimeLimit가 합리적인 범위"() {
+        expect: "라운드 시간 제한은 10~300초 범위"
+        GameConfig.roundTimeLimit() >= 10
+        GameConfig.roundTimeLimit() <= 300
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/enums/GameStatusSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/enums/GameStatusSpec.groovy
@@ -1,0 +1,95 @@
+package com.mzc.secondproject.serverless.domain.chatting.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GameStatusSpec extends Specification {
+
+    // ==================== isValid Tests ====================
+
+    @Unroll
+    def "isValid: '#value' -> #expected"() {
+        expect:
+        GameStatus.isValid(value) == expected
+
+        where:
+        value       | expected
+        "NONE"      | true
+        "WAITING"   | true
+        "PLAYING"   | true
+        "ROUND_END" | true
+        "FINISHED"  | true
+        "none"      | true
+        "waiting"   | true
+        "INVALID"   | false
+        ""          | false
+        null        | false
+    }
+
+    // ==================== fromString Tests ====================
+
+    @Unroll
+    def "fromString: '#value' -> #expected"() {
+        expect:
+        GameStatus.fromString(value) == expected
+
+        where:
+        value       | expected
+        "NONE"      | GameStatus.NONE
+        "none"      | GameStatus.NONE
+        "WAITING"   | GameStatus.WAITING
+        "waiting"   | GameStatus.WAITING
+        "PLAYING"   | GameStatus.PLAYING
+        "ROUND_END" | GameStatus.ROUND_END
+        "FINISHED"  | GameStatus.FINISHED
+        null        | GameStatus.NONE
+        "INVALID"   | GameStatus.NONE
+    }
+
+    // ==================== isGameActive Tests ====================
+
+    def "isGameActive: PLAYING과 ROUND_END만 true"() {
+        expect:
+        GameStatus.NONE.isGameActive() == false
+        GameStatus.WAITING.isGameActive() == false
+        GameStatus.PLAYING.isGameActive() == true
+        GameStatus.ROUND_END.isGameActive() == true
+        GameStatus.FINISHED.isGameActive() == false
+    }
+
+    // ==================== canStartGame Tests ====================
+
+    def "canStartGame: NONE과 FINISHED만 true"() {
+        expect:
+        GameStatus.NONE.canStartGame() == true
+        GameStatus.WAITING.canStartGame() == false
+        GameStatus.PLAYING.canStartGame() == false
+        GameStatus.ROUND_END.canStartGame() == false
+        GameStatus.FINISHED.canStartGame() == true
+    }
+
+    // ==================== Getter Tests ====================
+
+    def "GameStatus 속성 정상 반환"() {
+        expect:
+        GameStatus.NONE.getCode() == "none"
+        GameStatus.NONE.getDisplayName() == "게임 없음"
+
+        GameStatus.WAITING.getCode() == "waiting"
+        GameStatus.WAITING.getDisplayName() == "게임 대기 중"
+
+        GameStatus.PLAYING.getCode() == "playing"
+        GameStatus.PLAYING.getDisplayName() == "게임 진행 중"
+
+        GameStatus.ROUND_END.getCode() == "round_end"
+        GameStatus.ROUND_END.getDisplayName() == "라운드 종료"
+
+        GameStatus.FINISHED.getCode() == "finished"
+        GameStatus.FINISHED.getDisplayName() == "게임 종료"
+    }
+
+    def "모든 GameStatus 값 존재 확인"() {
+        expect: "5개의 상태 존재"
+        GameStatus.values().length == 5
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCodeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCodeSpec.groovy
@@ -1,0 +1,75 @@
+package com.mzc.secondproject.serverless.domain.chatting.exception
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ChattingErrorCodeSpec extends Specification {
+
+    def "모든 에러 코드의 도메인은 CHATTING"() {
+        expect:
+        ChattingErrorCode.values().every { it.getDomain() == "CHATTING" }
+    }
+
+    @Unroll
+    def "에러 코드 '#errorCode': code=#expectedCode, statusCode=#expectedStatusCode"() {
+        expect:
+        errorCode.getCode() == expectedCode
+        errorCode.getStatusCode() == expectedStatusCode
+        errorCode.getMessage() != null
+        !errorCode.getMessage().isEmpty()
+
+        where:
+        errorCode                                 | expectedCode    | expectedStatusCode
+        ChattingErrorCode.ROOM_NOT_FOUND          | "ROOM_001"      | 404
+        ChattingErrorCode.ROOM_ALREADY_EXISTS     | "ROOM_002"      | 409
+        ChattingErrorCode.ROOM_FULL               | "ROOM_003"      | 400
+        ChattingErrorCode.ROOM_CLOSED             | "ROOM_004"      | 400
+        ChattingErrorCode.ROOM_INVALID_PASSWORD   | "ROOM_005"      | 401
+        ChattingErrorCode.ROOM_NOT_OWNER          | "ROOM_006"      | 403
+        ChattingErrorCode.MESSAGE_NOT_FOUND       | "MSG_001"       | 404
+        ChattingErrorCode.MESSAGE_TOO_LONG        | "MSG_002"       | 400
+        ChattingErrorCode.INVALID_MESSAGE_TYPE    | "MSG_003"       | 400
+        ChattingErrorCode.NOT_ROOM_MEMBER         | "MEMBER_001"    | 403
+        ChattingErrorCode.ALREADY_JOINED          | "MEMBER_002"    | 409
+        ChattingErrorCode.INVALID_ROOM_TOKEN      | "MEMBER_003"    | 401
+        ChattingErrorCode.INVALID_CHAT_LEVEL      | "LEVEL_001"     | 400
+        ChattingErrorCode.CONNECTION_FAILED       | "CONN_001"      | 500
+        ChattingErrorCode.CONNECTION_TIMEOUT      | "CONN_002"      | 408
+        ChattingErrorCode.GAME_START_FAILED       | "GAME_001"      | 400
+        ChattingErrorCode.GAME_STOP_FAILED        | "GAME_002"      | 400
+        ChattingErrorCode.GAME_NOT_IN_PROGRESS    | "GAME_003"      | 400
+        ChattingErrorCode.GAME_ALREADY_IN_PROGRESS| "GAME_004"      | 409
+        ChattingErrorCode.NOT_GAME_STARTER        | "GAME_005"      | 403
+    }
+
+    def "모든 에러 코드 개수 확인"() {
+        expect: "20개의 에러 코드 존재"
+        ChattingErrorCode.values().length == 20
+    }
+
+    def "채팅방 관련 에러 코드들 (ROOM_XXX)"() {
+        expect:
+        ChattingErrorCode.ROOM_NOT_FOUND.getCode().startsWith("ROOM_")
+        ChattingErrorCode.ROOM_ALREADY_EXISTS.getCode().startsWith("ROOM_")
+        ChattingErrorCode.ROOM_FULL.getCode().startsWith("ROOM_")
+        ChattingErrorCode.ROOM_CLOSED.getCode().startsWith("ROOM_")
+        ChattingErrorCode.ROOM_INVALID_PASSWORD.getCode().startsWith("ROOM_")
+        ChattingErrorCode.ROOM_NOT_OWNER.getCode().startsWith("ROOM_")
+    }
+
+    def "메시지 관련 에러 코드들 (MSG_XXX)"() {
+        expect:
+        ChattingErrorCode.MESSAGE_NOT_FOUND.getCode().startsWith("MSG_")
+        ChattingErrorCode.MESSAGE_TOO_LONG.getCode().startsWith("MSG_")
+        ChattingErrorCode.INVALID_MESSAGE_TYPE.getCode().startsWith("MSG_")
+    }
+
+    def "게임 관련 에러 코드들 (GAME_XXX)"() {
+        expect:
+        ChattingErrorCode.GAME_START_FAILED.getCode().startsWith("GAME_")
+        ChattingErrorCode.GAME_STOP_FAILED.getCode().startsWith("GAME_")
+        ChattingErrorCode.GAME_NOT_IN_PROGRESS.getCode().startsWith("GAME_")
+        ChattingErrorCode.GAME_ALREADY_IN_PROGRESS.getCode().startsWith("GAME_")
+        ChattingErrorCode.NOT_GAME_STARTER.getCode().startsWith("GAME_")
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingExceptionSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingExceptionSpec.groovy
@@ -1,0 +1,195 @@
+package com.mzc.secondproject.serverless.domain.chatting.exception
+
+import spock.lang.Specification
+
+class ChattingExceptionSpec extends Specification {
+
+    // ==================== 채팅방(Room) 관련 예외 Tests ====================
+
+    def "roomNotFound: roomId 포함"() {
+        given:
+        def roomId = "room123"
+
+        when:
+        def exception = ChattingException.roomNotFound(roomId)
+
+        then:
+        exception.getMessage().contains(roomId)
+        exception.getErrorCode() == ChattingErrorCode.ROOM_NOT_FOUND
+        exception.getStatusCode() == 404
+    }
+
+    def "roomAlreadyExists: roomName 포함"() {
+        given:
+        def roomName = "영어 스터디방"
+
+        when:
+        def exception = ChattingException.roomAlreadyExists(roomName)
+
+        then:
+        exception.getMessage().contains(roomName)
+        exception.getErrorCode() == ChattingErrorCode.ROOM_ALREADY_EXISTS
+        exception.getStatusCode() == 409
+    }
+
+    def "roomFull: roomId와 maxCapacity 포함"() {
+        when:
+        def exception = ChattingException.roomFull("room123", 10)
+
+        then:
+        exception.getMessage().contains("10")
+        exception.getErrorCode() == ChattingErrorCode.ROOM_FULL
+    }
+
+    def "roomClosed: roomId 포함"() {
+        given:
+        def roomId = "closedRoom456"
+
+        when:
+        def exception = ChattingException.roomClosed(roomId)
+
+        then:
+        exception.getMessage().contains(roomId)
+        exception.getMessage().contains("종료")
+        exception.getErrorCode() == ChattingErrorCode.ROOM_CLOSED
+    }
+
+    def "roomInvalidPassword: 적절한 메시지"() {
+        when:
+        def exception = ChattingException.roomInvalidPassword("room123")
+
+        then:
+        exception.getMessage().contains("비밀번호")
+        exception.getErrorCode() == ChattingErrorCode.ROOM_INVALID_PASSWORD
+    }
+
+    def "roomNotOwner: userId와 roomId 포함"() {
+        when:
+        def exception = ChattingException.roomNotOwner("user123", "room456")
+
+        then:
+        exception.getMessage().contains("user123")
+        exception.getMessage().contains("room456")
+        exception.getMessage().contains("방장")
+        exception.getErrorCode() == ChattingErrorCode.ROOM_NOT_OWNER
+    }
+
+    // ==================== 메시지(Message) 관련 예외 Tests ====================
+
+    def "messageNotFound: messageId 포함"() {
+        given:
+        def messageId = "msg123"
+
+        when:
+        def exception = ChattingException.messageNotFound(messageId)
+
+        then:
+        exception.getMessage().contains(messageId)
+        exception.getErrorCode() == ChattingErrorCode.MESSAGE_NOT_FOUND
+    }
+
+    def "messageTooLong: length와 maxLength 포함"() {
+        when:
+        def exception = ChattingException.messageTooLong(1500, 1000)
+
+        then:
+        exception.getMessage().contains("1500")
+        exception.getMessage().contains("1000")
+        exception.getErrorCode() == ChattingErrorCode.MESSAGE_TOO_LONG
+    }
+
+    def "invalidMessageType: type 포함"() {
+        given:
+        def type = "INVALID_TYPE"
+
+        when:
+        def exception = ChattingException.invalidMessageType(type)
+
+        then:
+        exception.getMessage().contains(type)
+        exception.getErrorCode() == ChattingErrorCode.INVALID_MESSAGE_TYPE
+    }
+
+    // ==================== 참여자(Member) 관련 예외 Tests ====================
+
+    def "notRoomMember: userId와 roomId 포함"() {
+        when:
+        def exception = ChattingException.notRoomMember("user123", "room456")
+
+        then:
+        exception.getMessage().contains("user123")
+        exception.getMessage().contains("room456")
+        exception.getErrorCode() == ChattingErrorCode.NOT_ROOM_MEMBER
+    }
+
+    def "alreadyJoined: userId와 roomId 포함"() {
+        when:
+        def exception = ChattingException.alreadyJoined("user123", "room456")
+
+        then:
+        exception.getMessage().contains("user123")
+        exception.getMessage().contains("room456")
+        exception.getMessage().contains("이미 참여")
+        exception.getErrorCode() == ChattingErrorCode.ALREADY_JOINED
+    }
+
+    def "invalidRoomToken: 기본 메시지"() {
+        when:
+        def exception = ChattingException.invalidRoomToken()
+
+        then:
+        exception.getErrorCode() == ChattingErrorCode.INVALID_ROOM_TOKEN
+    }
+
+    def "invalidRoomToken: 커스텀 메시지"() {
+        given:
+        def reason = "토큰이 만료되었습니다"
+
+        when:
+        def exception = ChattingException.invalidRoomToken(reason)
+
+        then:
+        exception.getMessage() == reason
+    }
+
+    // ==================== 채팅 레벨 관련 예외 Tests ====================
+
+    def "invalidChatLevel: level 포함"() {
+        given:
+        def level = "EXPERT"
+
+        when:
+        def exception = ChattingException.invalidChatLevel(level)
+
+        then:
+        exception.getMessage().contains(level)
+        exception.getErrorCode() == ChattingErrorCode.INVALID_CHAT_LEVEL
+    }
+
+    // ==================== 연결 관련 예외 Tests ====================
+
+    def "connectionFailed: cause 포함"() {
+        given:
+        def cause = new RuntimeException("Connection refused")
+
+        when:
+        def exception = ChattingException.connectionFailed(cause)
+
+        then:
+        exception.getCause() == cause
+        exception.getErrorCode() == ChattingErrorCode.CONNECTION_FAILED
+    }
+
+    def "connectionTimeout: connectionId 포함"() {
+        given:
+        def connectionId = "conn123"
+
+        when:
+        def exception = ChattingException.connectionTimeout(connectionId)
+
+        then:
+        exception.getMessage().contains(connectionId)
+        exception.getMessage().contains("시간")
+        exception.getErrorCode() == ChattingErrorCode.CONNECTION_TIMEOUT
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/config/GrammarConfigSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/config/GrammarConfigSpec.groovy
@@ -1,0 +1,47 @@
+package com.mzc.secondproject.serverless.domain.grammar.config
+
+import spock.lang.Specification
+
+class GrammarConfigSpec extends Specification {
+
+    def "sessionTtlDays 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        GrammarConfig.sessionTtlDays() > 0
+    }
+
+    def "maxHistoryMessages 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        GrammarConfig.maxHistoryMessages() > 0
+    }
+
+    def "lastMessageMaxLength 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        GrammarConfig.lastMessageMaxLength() > 0
+    }
+
+    def "maxTokens 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        GrammarConfig.maxTokens() > 0
+    }
+
+    // ==================== Business Logic Tests ====================
+
+    def "모든 설정값이 양수"() {
+        expect:
+        GrammarConfig.sessionTtlDays() > 0
+        GrammarConfig.maxHistoryMessages() > 0
+        GrammarConfig.lastMessageMaxLength() > 0
+        GrammarConfig.maxTokens() > 0
+    }
+
+    def "maxTokens가 합리적인 범위"() {
+        expect: "토큰 수는 1000 이상이어야 함"
+        GrammarConfig.maxTokens() >= 1000
+    }
+
+    def "maxHistoryMessages가 합리적인 범위"() {
+        expect: "히스토리 메시지 수는 1~100 범위"
+        GrammarConfig.maxHistoryMessages() >= 1
+        GrammarConfig.maxHistoryMessages() <= 100
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/enums/GrammarLevelSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/enums/GrammarLevelSpec.groovy
@@ -1,0 +1,99 @@
+package com.mzc.secondproject.serverless.domain.grammar.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GrammarLevelSpec extends Specification {
+
+    // ==================== isValid Tests ====================
+
+    @Unroll
+    def "isValid: '#value' -> #expected"() {
+        expect:
+        GrammarLevel.isValid(value) == expected
+
+        where:
+        value          | expected
+        "BEGINNER"     | true
+        "INTERMEDIATE" | true
+        "ADVANCED"     | true
+        "beginner"     | true
+        "intermediate" | true
+        "advanced"     | true
+        "INVALID"      | false
+        ""             | false
+        null           | false
+    }
+
+    // ==================== fromString Tests ====================
+
+    @Unroll
+    def "fromString: '#value' -> #expected"() {
+        when:
+        def result = GrammarLevel.fromString(value)
+
+        then:
+        result == expected
+
+        where:
+        value          | expected
+        "BEGINNER"     | GrammarLevel.BEGINNER
+        "beginner"     | GrammarLevel.BEGINNER
+        "INTERMEDIATE" | GrammarLevel.INTERMEDIATE
+        "intermediate" | GrammarLevel.INTERMEDIATE
+        "ADVANCED"     | GrammarLevel.ADVANCED
+        "advanced"     | GrammarLevel.ADVANCED
+    }
+
+    def "fromString: null 입력 시 IllegalArgumentException 발생"() {
+        when:
+        GrammarLevel.fromString(null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "fromString: 잘못된 값 입력 시 IllegalArgumentException 발생"() {
+        when:
+        GrammarLevel.fromString("INVALID")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    // ==================== fromStringOrDefault Tests ====================
+
+    @Unroll
+    def "fromStringOrDefault: '#value' with default #defaultValue -> #expected"() {
+        expect:
+        GrammarLevel.fromStringOrDefault(value, defaultValue) == expected
+
+        where:
+        value      | defaultValue            | expected
+        "BEGINNER" | GrammarLevel.ADVANCED   | GrammarLevel.BEGINNER
+        null       | GrammarLevel.BEGINNER   | GrammarLevel.BEGINNER
+        "INVALID"  | GrammarLevel.INTERMEDIATE | GrammarLevel.INTERMEDIATE
+    }
+
+    // ==================== Getter Tests ====================
+
+    def "GrammarLevel 속성 정상 반환"() {
+        expect:
+        GrammarLevel.BEGINNER.getCode() == "beginner"
+        GrammarLevel.BEGINNER.getDisplayName() == "초급"
+        GrammarLevel.BEGINNER.getDescription() == "한국어 번역과 쉬운 설명 포함"
+
+        GrammarLevel.INTERMEDIATE.getCode() == "intermediate"
+        GrammarLevel.INTERMEDIATE.getDisplayName() == "중급"
+        GrammarLevel.INTERMEDIATE.getDescription() == "영어 위주 설명"
+
+        GrammarLevel.ADVANCED.getCode() == "advanced"
+        GrammarLevel.ADVANCED.getDisplayName() == "고급"
+        GrammarLevel.ADVANCED.getDescription() == "상세한 문법 규칙 설명"
+    }
+
+    def "모든 GrammarLevel 값 존재 확인"() {
+        expect: "3개의 레벨 존재"
+        GrammarLevel.values().length == 3
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarErrorCodeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarErrorCodeSpec.groovy
@@ -1,0 +1,53 @@
+package com.mzc.secondproject.serverless.domain.grammar.exception
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GrammarErrorCodeSpec extends Specification {
+
+    def "모든 에러 코드의 도메인은 GRAMMAR"() {
+        expect:
+        GrammarErrorCode.values().every { it.getDomain() == "GRAMMAR" }
+    }
+
+    @Unroll
+    def "에러 코드 '#errorCode': code=#expectedCode, statusCode=#expectedStatusCode"() {
+        expect:
+        errorCode.getCode() == expectedCode
+        errorCode.getStatusCode() == expectedStatusCode
+        errorCode.getMessage() != null
+        !errorCode.getMessage().isEmpty()
+
+        where:
+        errorCode                                        | expectedCode     | expectedStatusCode
+        GrammarErrorCode.INVALID_REQUEST                 | "GRAMMAR_000"    | 400
+        GrammarErrorCode.INVALID_SENTENCE                | "GRAMMAR_001"    | 400
+        GrammarErrorCode.GRAMMAR_CHECK_FAILED            | "GRAMMAR_002"    | 500
+        GrammarErrorCode.INVALID_LEVEL                   | "GRAMMAR_003"    | 400
+        GrammarErrorCode.BEDROCK_API_ERROR               | "GRAMMAR_004"    | 502
+        GrammarErrorCode.BEDROCK_RESPONSE_PARSE_ERROR    | "GRAMMAR_005"    | 500
+        GrammarErrorCode.SESSION_NOT_FOUND               | "GRAMMAR_006"    | 404
+        GrammarErrorCode.SESSION_EXPIRED                 | "GRAMMAR_007"    | 410
+    }
+
+    def "모든 에러 코드 개수 확인"() {
+        expect: "8개의 에러 코드 존재"
+        GrammarErrorCode.values().length == 8
+    }
+
+    def "클라이언트 에러 확인 (4xx)"() {
+        expect:
+        GrammarErrorCode.INVALID_REQUEST.isClientError()
+        GrammarErrorCode.INVALID_SENTENCE.isClientError()
+        GrammarErrorCode.INVALID_LEVEL.isClientError()
+        GrammarErrorCode.SESSION_NOT_FOUND.isClientError()
+        GrammarErrorCode.SESSION_EXPIRED.isClientError()
+    }
+
+    def "서버 에러 확인 (5xx)"() {
+        expect:
+        GrammarErrorCode.GRAMMAR_CHECK_FAILED.isServerError()
+        GrammarErrorCode.BEDROCK_API_ERROR.isServerError()
+        GrammarErrorCode.BEDROCK_RESPONSE_PARSE_ERROR.isServerError()
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarExceptionSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/grammar/exception/GrammarExceptionSpec.groovy
@@ -1,0 +1,116 @@
+package com.mzc.secondproject.serverless.domain.grammar.exception
+
+import spock.lang.Specification
+
+class GrammarExceptionSpec extends Specification {
+
+    // ==================== 요청 검증 관련 예외 Tests ====================
+
+    def "invalidRequest: 필드와 사유 포함"() {
+        when:
+        def exception = GrammarException.invalidRequest("sentence", "문장이 비어있습니다")
+
+        then:
+        exception.getMessage().contains("잘못된 요청")
+        exception.getErrorCode() == GrammarErrorCode.INVALID_REQUEST
+        exception.getStatusCode() == 400
+    }
+
+    // ==================== 문법 체크 관련 예외 Tests ====================
+
+    def "invalidSentence: 문장 포함"() {
+        given:
+        def sentence = "This is invalid."
+
+        when:
+        def exception = GrammarException.invalidSentence(sentence)
+
+        then:
+        exception.getMessage().contains("유효하지 않은 문장")
+        exception.getErrorCode() == GrammarErrorCode.INVALID_SENTENCE
+    }
+
+    def "grammarCheckFailed: 사유 포함"() {
+        given:
+        def reason = "AI 서비스 연결 실패"
+
+        when:
+        def exception = GrammarException.grammarCheckFailed(reason)
+
+        then:
+        exception.getMessage().contains(reason)
+        exception.getErrorCode() == GrammarErrorCode.GRAMMAR_CHECK_FAILED
+    }
+
+    // ==================== 레벨 관련 예외 Tests ====================
+
+    def "invalidLevel: 레벨과 허용값 포함"() {
+        given:
+        def level = "EXPERT"
+
+        when:
+        def exception = GrammarException.invalidLevel(level)
+
+        then:
+        exception.getMessage().contains(level)
+        exception.getMessage().contains("BEGINNER")
+        exception.getMessage().contains("INTERMEDIATE")
+        exception.getMessage().contains("ADVANCED")
+        exception.getErrorCode() == GrammarErrorCode.INVALID_LEVEL
+    }
+
+    // ==================== Bedrock API 관련 예외 Tests ====================
+
+    def "bedrockApiError: cause 포함"() {
+        given:
+        def cause = new RuntimeException("Connection refused")
+
+        when:
+        def exception = GrammarException.bedrockApiError(cause)
+
+        then:
+        exception.getCause() == cause
+        exception.getErrorCode() == GrammarErrorCode.BEDROCK_API_ERROR
+        exception.getStatusCode() == 502
+    }
+
+    def "bedrockResponseParseError: 응답 포함"() {
+        given:
+        def response = "{ invalid json }"
+
+        when:
+        def exception = GrammarException.bedrockResponseParseError(response)
+
+        then:
+        exception.getMessage().contains("파싱")
+        exception.getErrorCode() == GrammarErrorCode.BEDROCK_RESPONSE_PARSE_ERROR
+    }
+
+    // ==================== 세션 관련 예외 Tests ====================
+
+    def "sessionNotFound: sessionId 포함"() {
+        given:
+        def sessionId = "session123"
+
+        when:
+        def exception = GrammarException.sessionNotFound(sessionId)
+
+        then:
+        exception.getMessage().contains(sessionId)
+        exception.getErrorCode() == GrammarErrorCode.SESSION_NOT_FOUND
+        exception.getStatusCode() == 404
+    }
+
+    def "sessionExpired: sessionId 포함"() {
+        given:
+        def sessionId = "expiredSession456"
+
+        when:
+        def exception = GrammarException.sessionExpired(sessionId)
+
+        then:
+        exception.getMessage().contains(sessionId)
+        exception.getMessage().contains("만료")
+        exception.getErrorCode() == GrammarErrorCode.SESSION_EXPIRED
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/config/VocabularyConfigSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/config/VocabularyConfigSpec.groovy
@@ -1,0 +1,47 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.config
+
+import spock.lang.Specification
+
+class VocabularyConfigSpec extends Specification {
+
+    def "newWordsCount 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        VocabularyConfig.newWordsCount() > 0
+    }
+
+    def "reviewWordsCount 기본값 확인"() {
+        expect: "환경 변수 미설정 시 기본값 반환"
+        VocabularyConfig.reviewWordsCount() > 0
+    }
+
+    def "transitionToReviewingThreshold 기본값 확인"() {
+        expect: "기본값은 2"
+        VocabularyConfig.transitionToReviewingThreshold() >= 1
+    }
+
+    def "transitionToMasteredThreshold 기본값 확인"() {
+        expect: "기본값은 5"
+        VocabularyConfig.transitionToMasteredThreshold() >= VocabularyConfig.transitionToReviewingThreshold()
+    }
+
+    def "secondIntervalDays 기본값 확인"() {
+        expect: "기본값은 6"
+        VocabularyConfig.secondIntervalDays() > 0
+    }
+
+    // ==================== Business Logic Tests ====================
+
+    def "transitionToMasteredThreshold가 transitionToReviewingThreshold보다 큼"() {
+        expect: "마스터 전이 임계값이 복습 전이 임계값보다 커야 함"
+        VocabularyConfig.transitionToMasteredThreshold() > VocabularyConfig.transitionToReviewingThreshold()
+    }
+
+    def "모든 설정값이 양수"() {
+        expect:
+        VocabularyConfig.newWordsCount() > 0
+        VocabularyConfig.reviewWordsCount() > 0
+        VocabularyConfig.transitionToReviewingThreshold() > 0
+        VocabularyConfig.transitionToMasteredThreshold() > 0
+        VocabularyConfig.secondIntervalDays() > 0
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/constants/VocabKeySpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/constants/VocabKeySpec.groovy
@@ -1,0 +1,97 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.constants
+
+import spock.lang.Specification
+
+class VocabKeySpec extends Specification {
+
+    // ==================== Word Key Tests ====================
+
+    def "wordPk: WORD# prefix 적용"() {
+        expect:
+        VocabKey.wordPk("word123") == "WORD#word123"
+    }
+
+    def "wordSk: WORD# prefix 적용"() {
+        expect:
+        VocabKey.wordSk("word456") == "WORD#word456"
+    }
+
+    // ==================== Daily Study Key Tests ====================
+
+    def "dailyPk: DAILY# prefix 적용"() {
+        expect:
+        VocabKey.dailyPk("user123") == "DAILY#user123"
+    }
+
+    def "dateSk: DATE# prefix 적용"() {
+        expect:
+        VocabKey.dateSk("2026-01-20") == "DATE#2026-01-20"
+    }
+
+    // ==================== Level/Category Key Tests ====================
+
+    def "levelPk: LEVEL# prefix 적용"() {
+        expect:
+        VocabKey.levelPk("BEGINNER") == "LEVEL#BEGINNER"
+        VocabKey.levelPk("INTERMEDIATE") == "LEVEL#INTERMEDIATE"
+        VocabKey.levelPk("ADVANCED") == "LEVEL#ADVANCED"
+    }
+
+    def "categoryPk: CATEGORY# prefix 적용"() {
+        expect:
+        VocabKey.categoryPk("TOEIC") == "CATEGORY#TOEIC"
+    }
+
+    def "statusSk: STATUS# prefix 적용"() {
+        expect:
+        VocabKey.statusSk("NEW") == "STATUS#NEW"
+        VocabKey.statusSk("LEARNING") == "STATUS#LEARNING"
+    }
+
+    // ==================== User Key Tests ====================
+
+    def "userReviewPk: USER#userId#REVIEW 형식"() {
+        expect:
+        VocabKey.userReviewPk("user123") == "USER#user123#REVIEW"
+    }
+
+    def "userStatusPk: USER#userId#STATUS 형식"() {
+        expect:
+        VocabKey.userStatusPk("user456") == "USER#user456#STATUS"
+    }
+
+    def "userGroupPk: USER#userId#GROUP 형식"() {
+        expect:
+        VocabKey.userGroupPk("user789") == "USER#user789#GROUP"
+    }
+
+    def "userBookmarkedPk: USER#userId#BOOKMARKED 형식"() {
+        expect:
+        VocabKey.userBookmarkedPk("user000") == "USER#user000#BOOKMARKED"
+    }
+
+    // ==================== Test Key Tests ====================
+
+    def "testPk: TEST# prefix 적용"() {
+        expect:
+        VocabKey.testPk("test123") == "TEST#test123"
+    }
+
+    // ==================== Constants Tests ====================
+
+    def "상수값 확인"() {
+        expect:
+        VocabKey.WORD == "WORD#"
+        VocabKey.DAILY == "DAILY#"
+        VocabKey.LEVEL == "LEVEL#"
+        VocabKey.CATEGORY == "CATEGORY#"
+        VocabKey.TEST == "TEST#"
+        VocabKey.DATE == "DATE#"
+        VocabKey.STATUS_PREFIX == "STATUS#"
+        VocabKey.SUFFIX_REVIEW == "#REVIEW"
+        VocabKey.SUFFIX_STATUS == "#STATUS"
+        VocabKey.SUFFIX_GROUP == "#GROUP"
+        VocabKey.SUFFIX_BOOKMARKED == "#BOOKMARKED"
+        VocabKey.DAILY_ALL == "DAILY#ALL"
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/enums/TestTypeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/enums/TestTypeSpec.groovy
@@ -1,0 +1,98 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class TestTypeSpec extends Specification {
+
+    // ==================== isValid Tests ====================
+
+    @Unroll
+    def "isValid: '#value' -> #expected"() {
+        expect: "유효성 검사 결과가 예상과 일치"
+        TestType.isValid(value) == expected
+
+        where:
+        value     | expected
+        "DAILY"   | true
+        "WEEKLY"  | true
+        "CUSTOM"  | true
+        "daily"   | true
+        "weekly"  | true
+        "custom"  | true
+        "Daily"   | true
+        "INVALID" | false
+        ""        | false
+        null      | false
+    }
+
+    // ==================== fromString Tests ====================
+
+    @Unroll
+    def "fromString: '#value' -> #expected"() {
+        when: "문자열로부터 TestType 변환"
+        def result = TestType.fromString(value)
+
+        then: "올바른 TestType 반환"
+        result == expected
+
+        where:
+        value    | expected
+        "DAILY"  | TestType.DAILY
+        "daily"  | TestType.DAILY
+        "WEEKLY" | TestType.WEEKLY
+        "weekly" | TestType.WEEKLY
+        "CUSTOM" | TestType.CUSTOM
+        "custom" | TestType.CUSTOM
+    }
+
+    def "fromString: null 입력 시 IllegalArgumentException 발생"() {
+        when: "null로 변환 시도"
+        TestType.fromString(null)
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    def "fromString: 잘못된 값 입력 시 IllegalArgumentException 발생"() {
+        when: "잘못된 값으로 변환 시도"
+        TestType.fromString("INVALID")
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    // ==================== fromStringOrDefault Tests ====================
+
+    @Unroll
+    def "fromStringOrDefault: '#value' with default #defaultValue -> #expected"() {
+        expect: "기본값 처리 정상 동작"
+        TestType.fromStringOrDefault(value, defaultValue) == expected
+
+        where:
+        value     | defaultValue    | expected
+        "DAILY"   | TestType.WEEKLY | TestType.DAILY
+        null      | TestType.DAILY  | TestType.DAILY
+        "INVALID" | TestType.CUSTOM | TestType.CUSTOM
+        ""        | TestType.WEEKLY | TestType.WEEKLY
+    }
+
+    // ==================== Getter Tests ====================
+
+    def "TestType 속성 정상 반환"() {
+        expect: "각 테스트 타입의 code와 displayName 확인"
+        TestType.DAILY.getCode() == "daily"
+        TestType.DAILY.getDisplayName() == "일일 테스트"
+
+        TestType.WEEKLY.getCode() == "weekly"
+        TestType.WEEKLY.getDisplayName() == "주간 테스트"
+
+        TestType.CUSTOM.getCode() == "custom"
+        TestType.CUSTOM.getDisplayName() == "사용자 지정 테스트"
+    }
+
+    def "모든 TestType 값 존재 확인"() {
+        expect: "3개의 테스트 타입 존재"
+        TestType.values().length == 3
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/enums/WordStatusSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/enums/WordStatusSpec.groovy
@@ -1,0 +1,109 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WordStatusSpec extends Specification {
+
+    // ==================== isValid Tests ====================
+
+    @Unroll
+    def "isValid: '#value' -> #expected"() {
+        expect: "유효성 검사 결과가 예상과 일치"
+        WordStatus.isValid(value) == expected
+
+        where:
+        value       | expected
+        "NEW"       | true
+        "LEARNING"  | true
+        "REVIEWING" | true
+        "MASTERED"  | true
+        "UNKNOWN"   | true
+        "new"       | true
+        "learning"  | true
+        "New"       | true
+        "INVALID"   | false
+        ""          | false
+        null        | false
+    }
+
+    // ==================== fromString Tests ====================
+
+    @Unroll
+    def "fromString: '#value' -> #expected"() {
+        when: "문자열로부터 WordStatus 변환"
+        def result = WordStatus.fromString(value)
+
+        then: "올바른 WordStatus 반환"
+        result == expected
+
+        where:
+        value       | expected
+        "NEW"       | WordStatus.NEW
+        "new"       | WordStatus.NEW
+        "LEARNING"  | WordStatus.LEARNING
+        "learning"  | WordStatus.LEARNING
+        "REVIEWING" | WordStatus.REVIEWING
+        "reviewing" | WordStatus.REVIEWING
+        "MASTERED"  | WordStatus.MASTERED
+        "mastered"  | WordStatus.MASTERED
+        "UNKNOWN"   | WordStatus.UNKNOWN
+        "unknown"   | WordStatus.UNKNOWN
+    }
+
+    def "fromString: null 입력 시 IllegalArgumentException 발생"() {
+        when: "null로 변환 시도"
+        WordStatus.fromString(null)
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    def "fromString: 잘못된 값 입력 시 IllegalArgumentException 발생"() {
+        when: "잘못된 값으로 변환 시도"
+        WordStatus.fromString("INVALID")
+
+        then: "예외 발생"
+        thrown(IllegalArgumentException)
+    }
+
+    // ==================== fromStringOrDefault Tests ====================
+
+    @Unroll
+    def "fromStringOrDefault: '#value' with default #defaultValue -> #expected"() {
+        expect: "기본값 처리 정상 동작"
+        WordStatus.fromStringOrDefault(value, defaultValue) == expected
+
+        where:
+        value     | defaultValue         | expected
+        "NEW"     | WordStatus.UNKNOWN   | WordStatus.NEW
+        null      | WordStatus.NEW       | WordStatus.NEW
+        "INVALID" | WordStatus.LEARNING  | WordStatus.LEARNING
+        ""        | WordStatus.REVIEWING | WordStatus.REVIEWING
+    }
+
+    // ==================== Getter Tests ====================
+
+    def "WordStatus 속성 정상 반환"() {
+        expect: "각 상태의 code와 displayName 확인"
+        WordStatus.NEW.getCode() == "new"
+        WordStatus.NEW.getDisplayName() == "새 단어"
+
+        WordStatus.LEARNING.getCode() == "learning"
+        WordStatus.LEARNING.getDisplayName() == "학습 중"
+
+        WordStatus.REVIEWING.getCode() == "reviewing"
+        WordStatus.REVIEWING.getDisplayName() == "복습 중"
+
+        WordStatus.MASTERED.getCode() == "mastered"
+        WordStatus.MASTERED.getDisplayName() == "완료"
+
+        WordStatus.UNKNOWN.getCode() == "unknown"
+        WordStatus.UNKNOWN.getDisplayName() == "모르겠음"
+    }
+
+    def "모든 WordStatus 값 존재 확인"() {
+        expect: "5개의 상태 존재"
+        WordStatus.values().length == 5
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyErrorCodeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyErrorCodeSpec.groovy
@@ -1,0 +1,59 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.exception
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class VocabularyErrorCodeSpec extends Specification {
+
+    def "모든 에러 코드의 도메인은 VOCABULARY"() {
+        expect: "모든 에러 코드의 도메인이 VOCABULARY"
+        VocabularyErrorCode.values().every { it.getDomain() == "VOCABULARY" }
+    }
+
+    @Unroll
+    def "에러 코드 '#errorCode': code=#expectedCode, statusCode=#expectedStatusCode"() {
+        expect:
+        errorCode.getCode() == expectedCode
+        errorCode.getStatusCode() == expectedStatusCode
+        errorCode.getMessage() != null
+        !errorCode.getMessage().isEmpty()
+
+        where:
+        errorCode                                    | expectedCode     | expectedStatusCode
+        VocabularyErrorCode.WORD_NOT_FOUND           | "WORD_001"       | 404
+        VocabularyErrorCode.WORD_ALREADY_EXISTS      | "WORD_002"       | 409
+        VocabularyErrorCode.INVALID_WORD_DATA        | "WORD_003"       | 400
+        VocabularyErrorCode.USER_WORD_NOT_FOUND      | "USER_WORD_001"  | 404
+        VocabularyErrorCode.INVALID_DIFFICULTY       | "USER_WORD_002"  | 400
+        VocabularyErrorCode.INVALID_WORD_STATUS      | "USER_WORD_003"  | 400
+        VocabularyErrorCode.DAILY_STUDY_NOT_FOUND    | "STUDY_001"      | 404
+        VocabularyErrorCode.STUDY_LIMIT_EXCEEDED     | "STUDY_002"      | 400
+        VocabularyErrorCode.INVALID_STUDY_LEVEL      | "STUDY_003"      | 400
+        VocabularyErrorCode.INVALID_CATEGORY         | "CATEGORY_001"   | 400
+        VocabularyErrorCode.INVALID_LEVEL            | "LEVEL_001"      | 400
+        VocabularyErrorCode.GROUP_NOT_FOUND          | "GROUP_001"      | 404
+        VocabularyErrorCode.GROUP_ALREADY_EXISTS     | "GROUP_002"      | 409
+        VocabularyErrorCode.TEST_NOT_FOUND           | "TEST_001"       | 404
+        VocabularyErrorCode.NO_WORDS_TO_TEST         | "TEST_002"       | 400
+    }
+
+    def "404 에러 코드들 확인"() {
+        expect: "404 상태 코드를 가진 에러들"
+        VocabularyErrorCode.WORD_NOT_FOUND.getStatusCode() == 404
+        VocabularyErrorCode.USER_WORD_NOT_FOUND.getStatusCode() == 404
+        VocabularyErrorCode.DAILY_STUDY_NOT_FOUND.getStatusCode() == 404
+        VocabularyErrorCode.GROUP_NOT_FOUND.getStatusCode() == 404
+        VocabularyErrorCode.TEST_NOT_FOUND.getStatusCode() == 404
+    }
+
+    def "409 에러 코드들 확인"() {
+        expect: "409 상태 코드를 가진 에러들 (Conflict)"
+        VocabularyErrorCode.WORD_ALREADY_EXISTS.getStatusCode() == 409
+        VocabularyErrorCode.GROUP_ALREADY_EXISTS.getStatusCode() == 409
+    }
+
+    def "모든 에러 코드 개수 확인"() {
+        expect: "15개의 에러 코드 존재"
+        VocabularyErrorCode.values().length == 15
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyExceptionSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/exception/VocabularyExceptionSpec.groovy
@@ -1,0 +1,190 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.exception
+
+import spock.lang.Specification
+
+class VocabularyExceptionSpec extends Specification {
+
+    // ==================== Word 관련 예외 Tests ====================
+
+    def "wordNotFound: 메시지에 wordId 포함"() {
+        given:
+        def wordId = "word123"
+
+        when:
+        def exception = VocabularyException.wordNotFound(wordId)
+
+        then:
+        exception.getMessage().contains(wordId)
+        exception.getErrorCode() == VocabularyErrorCode.WORD_NOT_FOUND
+    }
+
+    def "wordAlreadyExists: 메시지에 영단어 포함"() {
+        given:
+        def english = "apple"
+
+        when:
+        def exception = VocabularyException.wordAlreadyExists(english)
+
+        then:
+        exception.getMessage().contains(english)
+        exception.getErrorCode() == VocabularyErrorCode.WORD_ALREADY_EXISTS
+    }
+
+    def "invalidWordData: 사유 메시지 포함"() {
+        given:
+        def reason = "영단어는 필수입니다"
+
+        when:
+        def exception = VocabularyException.invalidWordData(reason)
+
+        then:
+        exception.getMessage() == reason
+        exception.getErrorCode() == VocabularyErrorCode.INVALID_WORD_DATA
+    }
+
+    // ==================== UserWord 관련 예외 Tests ====================
+
+    def "userWordNotFound: userId와 wordId 포함"() {
+        given:
+        def userId = "user123"
+        def wordId = "word456"
+
+        when:
+        def exception = VocabularyException.userWordNotFound(userId, wordId)
+
+        then:
+        exception.getMessage().contains(userId)
+        exception.getMessage().contains(wordId)
+        exception.getErrorCode() == VocabularyErrorCode.USER_WORD_NOT_FOUND
+    }
+
+    def "invalidDifficulty: 잘못된 난이도 값 포함"() {
+        given:
+        def difficulty = "VERY_HARD"
+
+        when:
+        def exception = VocabularyException.invalidDifficulty(difficulty)
+
+        then:
+        exception.getMessage().contains(difficulty)
+        exception.getMessage().contains("EASY")
+        exception.getMessage().contains("NORMAL")
+        exception.getMessage().contains("HARD")
+        exception.getErrorCode() == VocabularyErrorCode.INVALID_DIFFICULTY
+    }
+
+    def "invalidWordStatus: 잘못된 상태 값 포함"() {
+        given:
+        def status = "INVALID_STATUS"
+
+        when:
+        def exception = VocabularyException.invalidWordStatus(status)
+
+        then:
+        exception.getMessage().contains(status)
+        exception.getErrorCode() == VocabularyErrorCode.INVALID_WORD_STATUS
+    }
+
+    // ==================== Study 관련 예외 Tests ====================
+
+    def "dailyStudyNotFound: userId와 date 포함"() {
+        given:
+        def userId = "user123"
+        def date = "2026-01-20"
+
+        when:
+        def exception = VocabularyException.dailyStudyNotFound(userId, date)
+
+        then:
+        exception.getMessage().contains(userId)
+        exception.getMessage().contains(date)
+        exception.getErrorCode() == VocabularyErrorCode.DAILY_STUDY_NOT_FOUND
+    }
+
+    def "studyLimitExceeded: 한도 값 포함"() {
+        given:
+        def limit = 50
+
+        when:
+        def exception = VocabularyException.studyLimitExceeded(limit)
+
+        then:
+        exception.getMessage().contains("50")
+        exception.getErrorCode() == VocabularyErrorCode.STUDY_LIMIT_EXCEEDED
+    }
+
+    def "invalidStudyLevel: 잘못된 레벨 값 포함"() {
+        given:
+        def level = "EXPERT"
+
+        when:
+        def exception = VocabularyException.invalidStudyLevel(level)
+
+        then:
+        exception.getMessage().contains(level)
+        exception.getErrorCode() == VocabularyErrorCode.INVALID_STUDY_LEVEL
+    }
+
+    // ==================== Category/Level 관련 예외 Tests ====================
+
+    def "invalidCategory: 잘못된 카테고리 값 포함"() {
+        given:
+        def category = "INVALID_CATEGORY"
+
+        when:
+        def exception = VocabularyException.invalidCategory(category)
+
+        then:
+        exception.getMessage().contains(category)
+        exception.getErrorCode() == VocabularyErrorCode.INVALID_CATEGORY
+    }
+
+    def "invalidLevel: 잘못된 레벨 값 포함"() {
+        given:
+        def level = "UNKNOWN_LEVEL"
+
+        when:
+        def exception = VocabularyException.invalidLevel(level)
+
+        then:
+        exception.getMessage().contains(level)
+        exception.getErrorCode() == VocabularyErrorCode.INVALID_LEVEL
+    }
+
+    // ==================== WordGroup 관련 예외 Tests ====================
+
+    def "groupNotFound: groupId 포함"() {
+        given:
+        def groupId = "group123"
+
+        when:
+        def exception = VocabularyException.groupNotFound(groupId)
+
+        then:
+        exception.getMessage().contains(groupId)
+        exception.getErrorCode() == VocabularyErrorCode.GROUP_NOT_FOUND
+    }
+
+    def "groupAlreadyExists: groupName 포함"() {
+        given:
+        def groupName = "My Vocabulary"
+
+        when:
+        def exception = VocabularyException.groupAlreadyExists(groupName)
+
+        then:
+        exception.getMessage().contains(groupName)
+        exception.getErrorCode() == VocabularyErrorCode.GROUP_ALREADY_EXISTS
+    }
+
+    // ==================== Test 관련 예외 Tests ====================
+
+    def "noWordsToTest: 적절한 메시지 포함"() {
+        when:
+        def exception = VocabularyException.noWordsToTest()
+
+        then:
+        exception.getMessage().contains("테스트할 단어가 없습니다")
+        exception.getErrorCode() == VocabularyErrorCode.NO_WORDS_TO_TEST
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/state/SpacedRepetitionContextSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/vocabulary/state/SpacedRepetitionContextSpec.groovy
@@ -1,0 +1,227 @@
+package com.mzc.secondproject.serverless.domain.vocabulary.state
+
+import com.mzc.secondproject.serverless.common.config.StudyConfig
+import spock.lang.Specification
+
+class SpacedRepetitionContextSpec extends Specification {
+
+    // ==================== 생성자 Tests ====================
+
+    def "기본 생성자: 초기값 설정 확인"() {
+        when:
+        def context = new SpacedRepetitionContext()
+
+        then:
+        context.getRepetitions() == StudyConfig.INITIAL_REPETITIONS
+        context.getInterval() == StudyConfig.INITIAL_INTERVAL_DAYS
+        context.getEaseFactor() == StudyConfig.DEFAULT_EASE_FACTOR
+        context.getCorrectCount() == StudyConfig.INITIAL_CORRECT_COUNT
+        context.getIncorrectCount() == StudyConfig.INITIAL_INCORRECT_COUNT
+    }
+
+    def "매개변수 생성자: 지정값 설정 확인"() {
+        given:
+        int repetitions = 3
+        int interval = 7
+        double easeFactor = 2.0
+        int correctCount = 5
+        int incorrectCount = 2
+
+        when:
+        def context = new SpacedRepetitionContext(repetitions, interval, easeFactor, correctCount, incorrectCount)
+
+        then:
+        context.getRepetitions() == 3
+        context.getInterval() == 7
+        context.getEaseFactor() == 2.0
+        context.getCorrectCount() == 5
+        context.getIncorrectCount() == 2
+    }
+
+    // ==================== Repetition Tests ====================
+
+    def "incrementRepetitions: 반복 횟수 증가"() {
+        given:
+        def context = new SpacedRepetitionContext()
+        def initial = context.getRepetitions()
+
+        when:
+        context.incrementRepetitions()
+
+        then:
+        context.getRepetitions() == initial + 1
+    }
+
+    def "resetRepetitions: 반복 횟수 초기화"() {
+        given:
+        def context = new SpacedRepetitionContext(5, 10, 2.5, 5, 0)
+
+        when:
+        context.resetRepetitions()
+
+        then:
+        context.getRepetitions() == StudyConfig.INITIAL_REPETITIONS
+    }
+
+    // ==================== Count Tests ====================
+
+    def "incrementCorrectCount: 정답 카운트 증가"() {
+        given:
+        def context = new SpacedRepetitionContext()
+
+        when:
+        context.incrementCorrectCount()
+        context.incrementCorrectCount()
+
+        then:
+        context.getCorrectCount() == 2
+    }
+
+    def "incrementIncorrectCount: 오답 카운트 증가"() {
+        given:
+        def context = new SpacedRepetitionContext()
+
+        when:
+        context.incrementIncorrectCount()
+
+        then:
+        context.getIncorrectCount() == 1
+    }
+
+    // ==================== Interval Tests ====================
+
+    def "updateInterval: 간격 업데이트"() {
+        given:
+        def context = new SpacedRepetitionContext()
+
+        when:
+        context.updateInterval(14)
+
+        then:
+        context.getInterval() == 14
+    }
+
+    def "resetInterval: 간격 초기화"() {
+        given:
+        def context = new SpacedRepetitionContext(3, 30, 2.5, 3, 0)
+
+        when:
+        context.resetInterval()
+
+        then:
+        context.getInterval() == StudyConfig.INITIAL_INTERVAL_DAYS
+    }
+
+    // ==================== EaseFactor Tests ====================
+
+    def "decreaseEaseFactor: easeFactor 감소"() {
+        given:
+        def context = new SpacedRepetitionContext()
+        def initial = context.getEaseFactor()
+
+        when:
+        context.decreaseEaseFactor()
+
+        then:
+        context.getEaseFactor() == initial - 0.2
+    }
+
+    def "decreaseEaseFactor: 최소값 보장"() {
+        given: "easeFactor가 최소값에 가까운 컨텍스트"
+        def context = new SpacedRepetitionContext(0, 1, 1.4, 0, 0)
+
+        when: "easeFactor 감소"
+        context.decreaseEaseFactor()
+
+        then: "최소값(1.3) 이하로 내려가지 않음"
+        context.getEaseFactor() >= StudyConfig.MIN_EASE_FACTOR
+    }
+
+    def "decreaseEaseFactor: 연속 감소 시 최소값 유지"() {
+        given:
+        def context = new SpacedRepetitionContext()
+
+        when: "여러 번 감소"
+        10.times { context.decreaseEaseFactor() }
+
+        then: "최소값 유지"
+        context.getEaseFactor() == StudyConfig.MIN_EASE_FACTOR
+    }
+
+    // ==================== calculateNextInterval Tests ====================
+
+    def "calculateNextInterval: interval * easeFactor 계산"() {
+        given:
+        def context = new SpacedRepetitionContext(2, 6, 2.5, 2, 0)
+
+        when:
+        def nextInterval = context.calculateNextInterval()
+
+        then: "6 * 2.5 = 15"
+        nextInterval == 15
+    }
+
+    def "calculateNextInterval: 소수점 반올림"() {
+        given:
+        def context = new SpacedRepetitionContext(3, 7, 2.5, 3, 0)
+
+        when:
+        def nextInterval = context.calculateNextInterval()
+
+        then: "7 * 2.5 = 17.5 -> 18 (반올림)"
+        nextInterval == 18
+    }
+
+    def "calculateNextInterval: 초기 상태"() {
+        given:
+        def context = new SpacedRepetitionContext()
+
+        when:
+        def nextInterval = context.calculateNextInterval()
+
+        then: "1 * 2.5 = 2.5 -> 3 (반올림)"
+        nextInterval == 3
+    }
+
+    // ==================== 복합 시나리오 Tests ====================
+
+    def "학습 시나리오: 연속 정답 후 interval 증가"() {
+        given:
+        def context = new SpacedRepetitionContext()
+
+        when: "3번 연속 정답"
+        context.incrementCorrectCount()
+        context.incrementRepetitions()
+        context.updateInterval(1)
+
+        context.incrementCorrectCount()
+        context.incrementRepetitions()
+        context.updateInterval(6)
+
+        context.incrementCorrectCount()
+        context.incrementRepetitions()
+        context.updateInterval(context.calculateNextInterval())
+
+        then:
+        context.getRepetitions() == 3
+        context.getCorrectCount() == 3
+        context.getInterval() == 15  // 6 * 2.5
+    }
+
+    def "학습 시나리오: 오답 후 리셋"() {
+        given: "진행 중인 학습 컨텍스트"
+        def context = new SpacedRepetitionContext(3, 14, 2.5, 3, 0)
+
+        when: "오답 처리"
+        context.incrementIncorrectCount()
+        context.resetRepetitions()
+        context.resetInterval()
+        context.decreaseEaseFactor()
+
+        then:
+        context.getRepetitions() == 0
+        context.getInterval() == 1
+        context.getIncorrectCount() == 1
+        context.getEaseFactor() == 2.3
+    }
+}


### PR DESCRIPTION
## Summary
- Groovy/Spock 기반 단위 테스트 26개 파일 추가 (2700+ lines)
- 순수 비즈니스 로직 및 유틸리티 클래스 테스트 커버리지 확보
- OPIc FeedbackResponse.java 문법 오류 수정 (빌드 차단 해결)

## 테스트 대상

### Common
- `StudyLevel`, `Difficulty` - enum 검증
- `StudyConfig`, `EnvConfig` - 설정값 검증
- `JsonUtil`, `CursorUtil` - 유틸리티 테스트
- `PaginatedResult` - DTO 테스트
- `CommonErrorCode`, `CommonException` - 예외 처리

### Vocabulary
- `WordStatus`, `TestType` - enum 검증
- `VocabularyConfig` - 설정값 검증
- `VocabKey` - 상수 생성 로직
- `VocabularyErrorCode`, `VocabularyException` - 예외 처리
- `SpacedRepetitionContext` - 학습 알고리즘 핵심 로직

### Badge
- `BadgeType` - enum 및 속성 검증
- `BadgeKey` - 상수 생성 로직

### Grammar
- `GrammarLevel` - enum 검증
- `GrammarConfig` - 설정값 검증
- `GrammarErrorCode`, `GrammarException` - 예외 처리

### Chatting
- `GameStatus` - enum 및 비즈니스 로직
- `GameConfig` - 설정값 검증
- `ChattingErrorCode`, `ChattingException` - 예외 처리

## 커버리지 결과
| 패키지 | 커버리지 |
|--------|---------|
| common.enums | 100% |
| badge.enums | 100% |
| vocabulary.state | 90%+ |
| vocabulary/grammar/chatting exceptions | 97-100% |
| config 패키지들 | 100% |
| constants 패키지들 | 100% |

## 80% 전체 커버리지 미달 사유
- 서비스 클래스들이 Repository를 생성자에서 직접 생성 (DI 패턴 미적용)
- Handler, Repository 클래스는 AWS 인프라 의존성 필요
- 추후 서비스 리팩토링 또는 통합 테스트로 보완 가능

## Test plan
- [x] `./gradlew test` - 모든 테스트 통과
- [x] `./gradlew jacocoTestReport` - 커버리지 리포트 생성

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)