### PR TITLE
feat: 게임 세션 REST API 구현

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
@@ -40,6 +40,7 @@ public enum ChattingErrorCode implements DomainErrorCode {
 	GAME_NOT_IN_PROGRESS("GAME_003", "진행 중인 게임이 없습니다", 400),
 	GAME_ALREADY_IN_PROGRESS("GAME_004", "이미 게임이 진행 중입니다", 409),
 	NOT_GAME_STARTER("GAME_005", "게임 시작자만 중단할 수 있습니다", 403),
+	GAME_NOT_FOUND("GAME_006", "게임 세션을 찾을 수 없습니다", 404),
 	;
 	
 	private static final String DOMAIN = "CHATTING";

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameSessionHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameSessionHandler.java
@@ -1,0 +1,266 @@
+package com.mzc.secondproject.serverless.domain.chatting.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.mzc.secondproject.serverless.common.router.HandlerRouter;
+import com.mzc.secondproject.serverless.common.router.Route;
+import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
+import com.mzc.secondproject.serverless.common.util.WebSocketBroadcaster;
+import com.mzc.secondproject.serverless.common.util.WebSocketMessageHelper;
+import com.mzc.secondproject.serverless.domain.chatting.dto.response.CommandResult;
+import com.mzc.secondproject.serverless.domain.chatting.enums.MessageType;
+import com.mzc.secondproject.serverless.domain.chatting.exception.ChattingErrorCode;
+import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
+import com.mzc.secondproject.serverless.domain.chatting.model.GameSession;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
+import com.mzc.secondproject.serverless.domain.chatting.repository.GameSessionRepository;
+import com.mzc.secondproject.serverless.domain.chatting.service.GameService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * 게임 세션 REST API 핸들러
+ * 게임 세션 조회 및 재접속 지원
+ */
+public class GameSessionHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+	private static final Logger logger = LoggerFactory.getLogger(GameSessionHandler.class);
+
+	private final GameService gameService;
+	private final GameSessionRepository gameSessionRepository;
+	private final ConnectionRepository connectionRepository;
+	private final WebSocketBroadcaster broadcaster;
+	private final HandlerRouter router;
+
+	public GameSessionHandler() {
+		this.gameService = new GameService();
+		this.gameSessionRepository = new GameSessionRepository();
+		this.connectionRepository = new ConnectionRepository();
+		this.broadcaster = new WebSocketBroadcaster();
+		this.router = initRouter();
+	}
+
+	private HandlerRouter initRouter() {
+		return new HandlerRouter().addRoutes(
+				// 게임 세션 생성 (roomId 기반)
+				Route.postAuth("/rooms/{roomId}/games", this::createGameSession),
+				// 게임 세션 조회 (재접속용)
+				Route.getAuth("/games/{gameSessionId}", this::getGameSession),
+				// 게임 시작
+				Route.postAuth("/games/{gameSessionId}/start", this::startGame),
+				// 게임 종료
+				Route.postAuth("/games/{gameSessionId}/stop", this::stopGame)
+		);
+	}
+
+	@Override
+	public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request, Context context) {
+		logger.info("GameSession API request: {} {}", request.getHttpMethod(), request.getPath());
+		return router.route(request);
+	}
+
+	/**
+	 * POST /rooms/{roomId}/games - 게임 세션 생성 (게임 시작)
+	 */
+	private APIGatewayProxyResponseEvent createGameSession(APIGatewayProxyRequestEvent request, String userId) {
+		String roomId = request.getPathParameters().get("roomId");
+
+		GameService.GameStartResult result = gameService.startGame(roomId, userId);
+
+		if (!result.success()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_START_FAILED, result.error());
+		}
+
+		// WebSocket으로 게임 시작 알림 브로드캐스트
+		broadcastGameStart(roomId, result);
+
+		// 응답 생성 (serverTime 포함)
+		Map<String, Object> response = buildGameSessionResponse(result.session(), userId);
+
+		return ResponseGenerator.ok("Game session created", response);
+	}
+
+	/**
+	 * GET /games/{gameSessionId} - 게임 세션 조회 (재접속용)
+	 */
+	private APIGatewayProxyResponseEvent getGameSession(APIGatewayProxyRequestEvent request, String userId) {
+		String gameSessionId = request.getPathParameters().get("gameSessionId");
+
+		Optional<GameSession> optSession = gameSessionRepository.findById(gameSessionId);
+		if (optSession.isEmpty()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_NOT_FOUND);
+		}
+
+		GameSession session = optSession.get();
+
+		// 응답 생성 (serverTime 포함, 출제자에게만 currentWord 포함)
+		Map<String, Object> response = buildGameSessionResponse(session, userId);
+
+		return ResponseGenerator.ok("Game session retrieved", response);
+	}
+
+	/**
+	 * POST /games/{gameSessionId}/start - 게임 시작 (세션 ID로)
+	 */
+	private APIGatewayProxyResponseEvent startGame(APIGatewayProxyRequestEvent request, String userId) {
+		String gameSessionId = request.getPathParameters().get("gameSessionId");
+
+		Optional<GameSession> optSession = gameSessionRepository.findById(gameSessionId);
+		if (optSession.isEmpty()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_NOT_FOUND);
+		}
+
+		GameSession session = optSession.get();
+
+		// 이미 시작된 게임인지 확인
+		if (session.isActive()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_START_FAILED, "게임이 이미 진행 중입니다.");
+		}
+
+		// roomId로 게임 시작 위임
+		GameService.GameStartResult result = gameService.startGame(session.getRoomId(), userId);
+
+		if (!result.success()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_START_FAILED, result.error());
+		}
+
+		broadcastGameStart(session.getRoomId(), result);
+
+		Map<String, Object> response = buildGameSessionResponse(result.session(), userId);
+		return ResponseGenerator.ok("Game started", response);
+	}
+
+	/**
+	 * POST /games/{gameSessionId}/stop - 게임 종료
+	 */
+	private APIGatewayProxyResponseEvent stopGame(APIGatewayProxyRequestEvent request, String userId) {
+		String gameSessionId = request.getPathParameters().get("gameSessionId");
+
+		Optional<GameSession> optSession = gameSessionRepository.findById(gameSessionId);
+		if (optSession.isEmpty()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_NOT_FOUND);
+		}
+
+		GameSession session = optSession.get();
+		CommandResult result = gameService.stopGame(session.getRoomId(), userId);
+
+		if (!result.success()) {
+			return ResponseGenerator.fail(ChattingErrorCode.GAME_STOP_FAILED, result.message());
+		}
+
+		// WebSocket으로 게임 종료 알림 브로드캐스트
+		broadcastSystemMessage(session.getRoomId(), result.message(), MessageType.GAME_END);
+
+		return ResponseGenerator.ok("Game stopped", Map.of(
+				"message", result.message(),
+				"serverTime", System.currentTimeMillis()
+		));
+	}
+
+	/**
+	 * 게임 세션 응답 빌드 (serverTime 포함)
+	 */
+	private Map<String, Object> buildGameSessionResponse(GameSession session, String userId) {
+		long serverTime = System.currentTimeMillis();
+
+		Map<String, Object> response = new LinkedHashMap<>();
+		response.put("gameSessionId", session.getGameSessionId());
+		response.put("roomId", session.getRoomId());
+		response.put("gameType", session.getGameType());
+		response.put("status", session.getStatus());
+		response.put("currentRound", session.getCurrentRound());
+		response.put("totalRounds", session.getTotalRounds());
+		response.put("currentDrawerId", session.getCurrentDrawerId());
+		response.put("roundStartTime", session.getRoundStartTime());
+		response.put("serverTime", serverTime);  // 핵심! 타이머 동기화용
+		response.put("roundDuration", session.getRoundDuration());
+		response.put("scores", session.getScores() != null ? session.getScores() : Map.of());
+		response.put("players", session.getPlayers() != null ? session.getPlayers() : List.of());
+		response.put("drawerOrder", session.getDrawerOrder());
+		response.put("hintUsed", session.getHintUsed());
+
+		// 출제자에게만 현재 단어 포함
+		if (userId != null && userId.equals(session.getCurrentDrawerId())) {
+			Map<String, String> currentWord = new HashMap<>();
+			currentWord.put("wordId", session.getCurrentWordId());
+			currentWord.put("word", session.getCurrentWord());
+			response.put("currentWord", currentWord);
+		}
+
+		return response;
+	}
+
+	/**
+	 * 게임 시작 브로드캐스트
+	 */
+	private void broadcastGameStart(String roomId, GameService.GameStartResult result) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+		long serverTime = System.currentTimeMillis();
+
+		GameSession session = result.session();
+
+		String message = String.format("""
+						🎮 게임 시작!
+						총 %d 라운드
+
+						라운드 1 시작!
+						출제자: %s
+						""",
+				session.getTotalRounds(),
+				session.getCurrentDrawerId());
+
+		Map<String, Object> gameStartMessage = new HashMap<>();
+		gameStartMessage.put("domain", WebSocketMessageHelper.DOMAIN_GAME);
+		gameStartMessage.put("messageId", messageId);
+		gameStartMessage.put("roomId", roomId);
+		gameStartMessage.put("userId", "SYSTEM");
+		gameStartMessage.put("content", message);
+		gameStartMessage.put("messageType", MessageType.GAME_START.getCode());
+		gameStartMessage.put("createdAt", now);
+		gameStartMessage.put("timestamp", serverTime);
+		gameStartMessage.put("gameStatus", session.getStatus());
+		gameStartMessage.put("currentRound", session.getCurrentRound());
+		gameStartMessage.put("totalRounds", session.getTotalRounds());
+		gameStartMessage.put("currentDrawerId", session.getCurrentDrawerId());
+		gameStartMessage.put("drawerOrder", result.drawerOrder());
+		gameStartMessage.put("roundStartTime", session.getRoundStartTime());
+		gameStartMessage.put("serverTime", serverTime);
+		gameStartMessage.put("roundDuration", session.getRoundDuration());
+
+		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		String broadcastPayload = ResponseGenerator.gson().toJson(gameStartMessage);
+		broadcaster.broadcast(connections, broadcastPayload);
+
+		logger.info("Game start broadcasted: roomId={}, sessionId={}", roomId, session.getGameSessionId());
+	}
+
+	/**
+	 * 시스템 메시지 브로드캐스트
+	 */
+	private void broadcastSystemMessage(String roomId, String message, MessageType messageType) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		Map<String, Object> systemMessage = new HashMap<>();
+		systemMessage.put("domain", WebSocketMessageHelper.DOMAIN_GAME);
+		systemMessage.put("messageId", messageId);
+		systemMessage.put("roomId", roomId);
+		systemMessage.put("userId", "SYSTEM");
+		systemMessage.put("content", message);
+		systemMessage.put("messageType", messageType.getCode());
+		systemMessage.put("createdAt", now);
+		systemMessage.put("timestamp", System.currentTimeMillis());
+
+		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		String broadcastPayload = ResponseGenerator.gson().toJson(systemMessage);
+		broadcaster.broadcast(connections, broadcastPayload);
+
+		logger.info("System message broadcasted: roomId={}, type={}", roomId, messageType);
+	}
+}


### PR DESCRIPTION
## Summary
- 게임 세션 관리를 위한 REST API 엔드포인트 추가
- 재접속 시 게임 상태 복구 지원
- 모든 응답에 serverTime 포함 (타이머 동기화)

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/rooms/{roomId}/games` | 게임 세션 생성 |
| GET | `/games/{gameSessionId}` | 게임 상태 조회 |
| POST | `/games/{gameSessionId}/start` | 게임 시작 |
| POST | `/games/{gameSessionId}/stop` | 게임 종료 |

## Response Example
```json
{
  "gameSessionId": "abc-123",
  "roomId": "room-xyz",
  "status": "PLAYING",
  "currentRound": 2,
  "totalRounds": 5,
  "roundStartTime": 1705744800000,
  "serverTime": 1705744830000,
  "roundDuration": 60,
  "scores": { "user1": 150 },
  "currentWord": { "word": "apple" }  // 출제자만
}
```

## Test Plan
- [ ] POST /rooms/{roomId}/games 게임 생성 확인
- [ ] GET /games/{gameSessionId} 조회 확인
- [ ] serverTime 필드 포함 확인
- [ ] 출제자에게만 currentWord 포함 확인

Closes #422, #432, #433