### PR TITLE
feat: 게임 시작 7분 후 자동 종료 기능 구현

### DIFF
--- a/ServerlessFunction/build.gradle
+++ b/ServerlessFunction/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'software.amazon.awssdk:apigatewaymanagementapi'
     implementation 'software.amazon.awssdk:url-connection-client'
     implementation 'software.amazon.awssdk:ssm'
+    implementation 'software.amazon.awssdk:scheduler'
 
     // AWS X-Ray SDK (다운스트림 서비스 추적용)
     implementation 'com.amazonaws:aws-xray-recorder-sdk-core:2.15.0'

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/config/GameConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/config/GameConfig.java
@@ -11,10 +11,12 @@ public final class GameConfig {
 	private static final int DEFAULT_TOTAL_ROUNDS = 5;
 	private static final int DEFAULT_ROUND_TIME_LIMIT = 60;
 	private static final long DEFAULT_QUICK_GUESS_THRESHOLD_MS = 5000L;
+	private static final int DEFAULT_GAME_TIME_LIMIT = 420; // 7분 (420초)
 
 	private static final int TOTAL_ROUNDS = EnvConfig.getIntOrDefault("GAME_TOTAL_ROUNDS", DEFAULT_TOTAL_ROUNDS);
 	private static final int ROUND_TIME_LIMIT = EnvConfig.getIntOrDefault("GAME_ROUND_TIME_LIMIT", DEFAULT_ROUND_TIME_LIMIT);
 	private static final long QUICK_GUESS_THRESHOLD_MS = EnvConfig.getLongOrDefault("GAME_QUICK_GUESS_THRESHOLD_MS", DEFAULT_QUICK_GUESS_THRESHOLD_MS);
+	private static final int GAME_TIME_LIMIT = EnvConfig.getIntOrDefault("GAME_TIME_LIMIT_SECONDS", DEFAULT_GAME_TIME_LIMIT);
 
 	private GameConfig() {
 	}
@@ -29,5 +31,13 @@ public final class GameConfig {
 
 	public static long quickGuessThresholdMs() {
 		return QUICK_GUESS_THRESHOLD_MS;
+	}
+
+	/**
+	 * 게임 전체 시간 제한 (초)
+	 * 기본값: 420초 (7분)
+	 */
+	public static int gameTimeLimit() {
+		return GAME_TIME_LIMIT;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameAutoCloseHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameAutoCloseHandler.java
@@ -1,0 +1,96 @@
+package com.mzc.secondproject.serverless.domain.chatting.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
+import com.mzc.secondproject.serverless.common.util.WebSocketBroadcaster;
+import com.mzc.secondproject.serverless.common.util.WebSocketMessageHelper;
+import com.mzc.secondproject.serverless.domain.chatting.dto.response.CommandResult;
+import com.mzc.secondproject.serverless.domain.chatting.enums.MessageType;
+import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
+import com.mzc.secondproject.serverless.domain.chatting.repository.ConnectionRepository;
+import com.mzc.secondproject.serverless.domain.chatting.service.GameService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 게임 자동 종료 Lambda 핸들러
+ * EventBridge Scheduler에 의해 게임 시작 7분 후 호출됨
+ */
+public class GameAutoCloseHandler implements RequestHandler<Map<String, String>, String> {
+
+	private static final Logger logger = LoggerFactory.getLogger(GameAutoCloseHandler.class);
+
+	private final GameService gameService;
+	private final ConnectionRepository connectionRepository;
+	private final WebSocketBroadcaster broadcaster;
+
+	public GameAutoCloseHandler() {
+		this.gameService = new GameService();
+		this.connectionRepository = new ConnectionRepository();
+		this.broadcaster = new WebSocketBroadcaster();
+	}
+
+	@Override
+	public String handleRequest(Map<String, String> event, Context context) {
+		String gameSessionId = event.get("gameSessionId");
+		String roomId = event.get("roomId");
+
+		logger.info("Game auto-close triggered: gameSessionId={}, roomId={}", gameSessionId, roomId);
+
+		if (gameSessionId == null || roomId == null) {
+			logger.error("Missing required parameters: gameSessionId={}, roomId={}", gameSessionId, roomId);
+			return "FAILED: Missing parameters";
+		}
+
+		try {
+			// 게임 종료 처리
+			CommandResult result = gameService.finishGameByTimeout(gameSessionId);
+
+			if (result.success()) {
+				// WebSocket으로 게임 종료 알림 브로드캐스트
+				broadcastGameEnd(roomId, result.message());
+				logger.info("Game auto-closed successfully: gameSessionId={}", gameSessionId);
+				return "SUCCESS: Game auto-closed";
+			} else {
+				logger.info("Game auto-close skipped: gameSessionId={}, reason={}", gameSessionId, result.message());
+				return "SKIPPED: " + result.message();
+			}
+
+		} catch (Exception e) {
+			logger.error("Game auto-close failed: gameSessionId={}, error={}", gameSessionId, e.getMessage(), e);
+			return "FAILED: " + e.getMessage();
+		}
+	}
+
+	/**
+	 * 게임 종료 메시지 브로드캐스트
+	 */
+	private void broadcastGameEnd(String roomId, String message) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		Map<String, Object> gameEndMessage = new HashMap<>();
+		gameEndMessage.put("domain", WebSocketMessageHelper.DOMAIN_GAME);
+		gameEndMessage.put("messageId", messageId);
+		gameEndMessage.put("roomId", roomId);
+		gameEndMessage.put("userId", "SYSTEM");
+		gameEndMessage.put("content", "⏰ 시간 초과! " + message);
+		gameEndMessage.put("messageType", MessageType.GAME_END.getCode());
+		gameEndMessage.put("createdAt", now);
+		gameEndMessage.put("timestamp", System.currentTimeMillis());
+		gameEndMessage.put("reason", "TIME_EXPIRED");
+
+		List<Connection> connections = connectionRepository.findByRoomId(roomId);
+		String broadcastPayload = ResponseGenerator.gson().toJson(gameEndMessage);
+		broadcaster.broadcast(connections, broadcastPayload);
+
+		logger.info("Game end broadcasted: roomId={}, connections={}", roomId, connections.size());
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameSchedulerClient.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameSchedulerClient.java
@@ -1,0 +1,139 @@
+package com.mzc.secondproject.serverless.domain.chatting.service;
+
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+import com.mzc.secondproject.serverless.domain.chatting.config.GameConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.scheduler.SchedulerClient;
+import software.amazon.awssdk.services.scheduler.model.*;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * EventBridge Scheduler를 사용한 게임 자동 종료 스케줄링
+ */
+public class GameSchedulerClient {
+
+	private static final Logger logger = LoggerFactory.getLogger(GameSchedulerClient.class);
+
+	private static final String SCHEDULE_GROUP = "game-auto-close";
+	private static final String SCHEDULE_NAME_PREFIX = "game-close-";
+
+	private final SchedulerClient schedulerClient;
+	private final String targetLambdaArn;
+	private final String roleArn;
+
+	public GameSchedulerClient() {
+		this.schedulerClient = SchedulerClient.create();
+		this.targetLambdaArn = EnvConfig.getOrDefault("GAME_AUTO_CLOSE_LAMBDA_ARN", null);
+		this.roleArn = EnvConfig.getOrDefault("SCHEDULER_ROLE_ARN", null);
+	}
+
+	/**
+	 * 게임 자동 종료 스케줄 생성
+	 *
+	 * @param gameSessionId 게임 세션 ID
+	 * @param roomId        방 ID
+	 * @return 스케줄 ARN (실패 시 null)
+	 */
+	public ScheduleResult createGameEndSchedule(String gameSessionId, String roomId) {
+		if (targetLambdaArn == null || roleArn == null) {
+			logger.warn("Scheduler not configured: GAME_AUTO_CLOSE_LAMBDA_ARN or SCHEDULER_ROLE_ARN not set");
+			return new ScheduleResult(null, 0L);
+		}
+
+		try {
+			// 7분 후 시간 계산
+			long scheduledAtMs = System.currentTimeMillis() + (GameConfig.gameTimeLimit() * 1000L);
+			Instant scheduledAt = Instant.ofEpochMilli(scheduledAtMs);
+
+			// at() 표현식: at(yyyy-mm-ddThh:mm:ss)
+			String atExpression = "at(" + DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+					.withZone(ZoneOffset.UTC)
+					.format(scheduledAt) + ")";
+
+			String scheduleName = SCHEDULE_NAME_PREFIX + gameSessionId;
+
+			// Lambda 호출 시 전달할 페이로드
+			String payload = String.format("{\"gameSessionId\":\"%s\",\"roomId\":\"%s\"}", gameSessionId, roomId);
+
+			CreateScheduleRequest request = CreateScheduleRequest.builder()
+					.name(scheduleName)
+					.groupName(SCHEDULE_GROUP)
+					.scheduleExpression(atExpression)
+					.scheduleExpressionTimezone("UTC")
+					.flexibleTimeWindow(FlexibleTimeWindow.builder()
+							.mode(FlexibleTimeWindowMode.OFF)
+							.build())
+					.target(Target.builder()
+							.arn(targetLambdaArn)
+							.roleArn(roleArn)
+							.input(payload)
+							.build())
+					.actionAfterCompletion(ActionAfterCompletion.DELETE) // 실행 후 자동 삭제
+					.build();
+
+			CreateScheduleResponse response = schedulerClient.createSchedule(request);
+
+			logger.info("Game end schedule created: gameSessionId={}, scheduledAt={}, arn={}",
+					gameSessionId, scheduledAt, response.scheduleArn());
+
+			return new ScheduleResult(response.scheduleArn(), scheduledAtMs);
+
+		} catch (ConflictException e) {
+			logger.warn("Schedule already exists: gameSessionId={}", gameSessionId);
+			return new ScheduleResult(null, 0L);
+
+		} catch (Exception e) {
+			logger.error("Failed to create game end schedule: gameSessionId={}, error={}",
+					gameSessionId, e.getMessage());
+			return new ScheduleResult(null, 0L);
+		}
+	}
+
+	/**
+	 * 게임 자동 종료 스케줄 취소
+	 *
+	 * @param gameSessionId 게임 세션 ID
+	 * @return 취소 성공 여부
+	 */
+	public boolean cancelGameEndSchedule(String gameSessionId) {
+		if (targetLambdaArn == null) {
+			return true; // 스케줄러 미설정 시 무시
+		}
+
+		try {
+			String scheduleName = SCHEDULE_NAME_PREFIX + gameSessionId;
+
+			DeleteScheduleRequest request = DeleteScheduleRequest.builder()
+					.name(scheduleName)
+					.groupName(SCHEDULE_GROUP)
+					.build();
+
+			schedulerClient.deleteSchedule(request);
+
+			logger.info("Game end schedule cancelled: gameSessionId={}", gameSessionId);
+			return true;
+
+		} catch (ResourceNotFoundException e) {
+			logger.debug("Schedule not found (may have already executed): gameSessionId={}", gameSessionId);
+			return true; // 이미 삭제되었거나 없는 경우
+
+		} catch (Exception e) {
+			logger.error("Failed to cancel game end schedule: gameSessionId={}, error={}",
+					gameSessionId, e.getMessage());
+			return false;
+		}
+	}
+
+	/**
+	 * 스케줄 생성 결과
+	 */
+	public record ScheduleResult(String scheduleArn, long scheduledAtMs) {
+		public boolean success() {
+			return scheduleArn != null;
+		}
+	}
+}

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -277,14 +277,31 @@ Resources:
       Environment:
         Variables:
           WEBSOCKET_ENDPOINT: !Sub "https://${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
+          GAME_AUTO_CLOSE_LAMBDA_ARN: !GetAtt GameAutoCloseFunction.Arn
+          SCHEDULER_ROLE_ARN: !GetAtt GameSchedulerRole.Arn
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ChatTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref VocabTable
         - Statement:
             - Effect: Allow
               Action:
                 - execute-api:ManageConnections
               Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*
+        # EventBridge Scheduler 권한
+        - Statement:
+            - Effect: Allow
+              Action:
+                - scheduler:CreateSchedule
+                - scheduler:DeleteSchedule
+                - scheduler:GetSchedule
+              Resource: !Sub "arn:aws:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/game-auto-close/*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - iam:PassRole
+              Resource: !GetAtt GameSchedulerRole.Arn
 
   WebSocketMessagePermission:
     Type: AWS::Lambda::Permission
@@ -410,6 +427,8 @@ Resources:
       Environment:
         Variables:
           WEBSOCKET_ENDPOINT: !Sub "https://${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
+          GAME_AUTO_CLOSE_LAMBDA_ARN: !GetAtt GameAutoCloseFunction.Arn
+          SCHEDULER_ROLE_ARN: !GetAtt GameSchedulerRole.Arn
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ChatTable
@@ -418,6 +437,19 @@ Resources:
               Action:
                 - execute-api:ManageConnections
               Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*"
+        # EventBridge Scheduler 권한
+        - Statement:
+            - Effect: Allow
+              Action:
+                - scheduler:CreateSchedule
+                - scheduler:DeleteSchedule
+                - scheduler:GetSchedule
+              Resource: !Sub "arn:aws:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/game-auto-close/*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - iam:PassRole
+              Resource: !GetAtt GameSchedulerRole.Arn
       Events:
         StartGame:
           Type: Api
@@ -451,6 +483,58 @@ Resources:
             Method: GET
             Auth:
               Authorizer: CognitoAuthorizer
+
+  # 게임 자동 종료 Lambda (EventBridge Scheduler에 의해 호출)
+  GameAutoCloseFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: group2-englishstudy-game-auto-close
+      CodeUri: .
+      Handler: com.mzc.secondproject.serverless.domain.chatting.handler.GameAutoCloseHandler::handleRequest
+      Description: Auto-close game after 7 minutes
+      Timeout: 30
+      MemorySize: 512
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Environment:
+        Variables:
+          WEBSOCKET_ENDPOINT: !Sub "https://${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref ChatTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - execute-api:ManageConnections
+              Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*"
+
+  # EventBridge Scheduler가 Lambda를 호출할 수 있는 IAM Role
+  GameSchedulerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-game-scheduler-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: scheduler.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: InvokeGameAutoCloseLambda
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource: !GetAtt GameAutoCloseFunction.Arn
+
+  # EventBridge Schedule Group
+  GameScheduleGroup:
+    Type: AWS::Scheduler::ScheduleGroup
+    Properties:
+      Name: game-auto-close
 
   ChatMessageFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## Summary
- 게임 시작 7분 후 자동 종료 기능 구현
- EventBridge Scheduler를 사용한 동적 스케줄링
- 수동 종료/라운드 완료 시 스케줄 자동 취소

## Changes
- `GameConfig.gameTimeLimit()` - 게임 시간 제한 설정 (기본 420초)
- `GameSchedulerClient` - EventBridge Scheduler 연동 유틸리티
- `GameAutoCloseHandler` - 스케줄러에 의해 호출되는 Lambda
- `GameService` - 스케줄 생성/취소 로직 추가
- `template.yaml` - Lambda, IAM Role, Schedule Group 추가

## Flow
```
[게임 시작]
    ↓
GameService.startGame()
    ↓
EventBridge Schedule 생성 (7분 후)
    ↓
... 7분 경과 ...
    ↓
GameAutoCloseHandler 실행
    ↓
finishGame(session, "TIME_EXPIRED")
    ↓
WebSocket으로 종료 알림 브로드캐스트
```

## Test plan
- [ ] 게임 시작 시 EventBridge Schedule 생성 확인
- [ ] 7분 후 자동 종료 및 WebSocket 알림 확인
- [ ] 수동 종료 시 Schedule 취소 확인
- [ ] 모든 라운드 완료 시 Schedule 취소 확인

Closes #417