### PR TITLE
[Bugfix] Cognito 트리거 람다 타임아웃 에러 해결 

### DIFF
--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -110,6 +110,8 @@ Resources:
       CodeUri: .
       Handler: com.mzc.secondproject.serverless.domain.user.handler.PostConfirmationHandler::handleRequest
       Description: Handle user registration - save to DynamoDB
+      MemorySize: 1024
+      Timeout: 5
       SnapStart:
         ApplyOn: PublishedVersions
       Policies:


### PR DESCRIPTION
## 문제 상황 
- Closes #360 

### 원인 분석
- Cognito Lambda 트리거는 Lambda Timeout 설정과 별개로 **Cognito 서비스 자체가 약 5초만 대기**
- 기존 Cold Start 시간이 5초를 초과하여 Socket timeout 발생
( 단, 에러 발생해도 사용자 상태는 CONFIRMED로 변경됨 - 기능상 문제 없음 )
## 작업 내용 
- `MemorySize`: 512MB → **1024MB** (메모리 증가 → CPU 할당 증가 → Cold Start 감소)
- `Timeout`: 30초 → **5초** (Cognito 제한에 맞춤)

### 테스트 결과

- [x] 회원가입 → 이메일 인증 시 타임아웃 에러 없음 확인

https://github.com/user-attachments/assets/80c44e75-5978-414f-8623-7e3369934015

- [x] CloudWatch 로그에서 정상 완료 확인
<img width="1445" height="67" alt="스크린샷 2026-01-20 오후 5 57 08" src="https://github.com/user-attachments/assets/83fe72a7-99d1-4b3b-9277-25c021a0398d" />

#### CloudWatch 로그
| 요청 | Init Duration | Duration | 총 시간 |
|------|---------------|----------|--------|
| Cold Start | 3,217ms | 1,082ms | ~4.3초 |
| Warm | - | 72ms | 0.07초  |


