### PR TITLE
feat: 캐치마인드 게임 방 분리 기능 구현

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/WebSocketMessageHelper.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/WebSocketMessageHelper.java
@@ -13,6 +13,7 @@ public final class WebSocketMessageHelper {
 
 	public static final String DOMAIN_CHAT = "chat";
 	public static final String DOMAIN_GAME = "game";
+	public static final String DOMAIN_ROOM = "room";
 
 	private WebSocketMessageHelper() {
 	}
@@ -105,5 +106,61 @@ public final class WebSocketMessageHelper {
 	 */
 	public static Map<String, Object> buildSystemMessage(String roomId, String content, String messageType) {
 		return buildChatMessage(roomId, "SYSTEM", content, messageType);
+	}
+
+	/**
+	 * 방 상태 변경 메시지 생성
+	 *
+	 * @param roomId         방 ID
+	 * @param status         현재 상태
+	 * @param previousStatus 이전 상태
+	 * @return 방 상태 변경 메시지
+	 */
+	public static Map<String, Object> buildRoomStatusChangeMessage(
+			String roomId,
+			String status,
+			String previousStatus
+	) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		Map<String, Object> message = new HashMap<>();
+		message.put("domain", DOMAIN_ROOM);
+		message.put("messageType", "room_status_change");
+		message.put("messageId", messageId);
+		message.put("roomId", roomId);
+		message.put("status", status);
+		message.put("previousStatus", previousStatus);
+		message.put("createdAt", now);
+		message.put("timestamp", System.currentTimeMillis());
+		return message;
+	}
+
+	/**
+	 * 방장 변경 메시지 생성
+	 *
+	 * @param roomId           방 ID
+	 * @param newHostId        새 방장 ID
+	 * @param newHostNickname  새 방장 닉네임
+	 * @return 방장 변경 메시지
+	 */
+	public static Map<String, Object> buildHostChangeMessage(
+			String roomId,
+			String newHostId,
+			String newHostNickname
+	) {
+		String messageId = UUID.randomUUID().toString();
+		String now = Instant.now().toString();
+
+		Map<String, Object> message = new HashMap<>();
+		message.put("domain", DOMAIN_ROOM);
+		message.put("messageType", "host_change");
+		message.put("messageId", messageId);
+		message.put("roomId", roomId);
+		message.put("newHostId", newHostId);
+		message.put("newHostNickname", newHostNickname);
+		message.put("createdAt", now);
+		message.put("timestamp", System.currentTimeMillis());
+		return message;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/CreateRoomRequest.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/dto/request/CreateRoomRequest.java
@@ -1,5 +1,6 @@
 package com.mzc.secondproject.serverless.domain.chatting.dto.request;
 
+import com.mzc.secondproject.serverless.domain.chatting.model.GameSettings;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -32,6 +33,13 @@ public class CreateRoomRequest {
 	
 	@Builder.Default
 	private Boolean isPrivate = false;
-	
+
 	private String password;
+
+	@Builder.Default
+	private String type = "CHAT";  // CHAT or GAME
+
+	private String gameType;       // CATCHMIND (nullable)
+
+	private GameSettings gameSettings;  // 게임 설정 (nullable)
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/MessageType.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/MessageType.java
@@ -18,7 +18,11 @@ public enum MessageType {
 	CORRECT_ANSWER("correct_answer", "정답"),
 	SCORE_UPDATE("score_update", "점수 업데이트"),
 	SYSTEM_COMMAND("system_command", "시스템 명령"),
-	HINT("hint", "힌트");
+	HINT("hint", "힌트"),
+
+	// 방 관련 메시지 타입
+	ROOM_STATUS_CHANGE("room_status_change", "방 상태 변경"),
+	HOST_CHANGE("host_change", "방장 변경");
 	
 	private final String code;
 	private final String displayName;

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomStatus.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomStatus.java
@@ -1,0 +1,39 @@
+package com.mzc.secondproject.serverless.domain.chatting.enums;
+
+import java.util.Arrays;
+
+public enum RoomStatus {
+	WAITING("waiting", "대기 중"),
+	PLAYING("playing", "게임 중"),
+	FINISHED("finished", "종료됨");
+
+	private final String code;
+	private final String displayName;
+
+	RoomStatus(String code, String displayName) {
+		this.code = code;
+		this.displayName = displayName;
+	}
+
+	public static boolean isValid(String value) {
+		if (value == null) return false;
+		return Arrays.stream(values())
+				.anyMatch(status -> status.name().equalsIgnoreCase(value) || status.code.equalsIgnoreCase(value));
+	}
+
+	public static RoomStatus fromString(String value) {
+		if (value == null) return WAITING;
+		return Arrays.stream(values())
+				.filter(status -> status.name().equalsIgnoreCase(value) || status.code.equalsIgnoreCase(value))
+				.findFirst()
+				.orElse(WAITING);
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomType.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomType.java
@@ -1,0 +1,38 @@
+package com.mzc.secondproject.serverless.domain.chatting.enums;
+
+import java.util.Arrays;
+
+public enum RoomType {
+	CHAT("chat", "채팅방"),
+	GAME("game", "게임방");
+
+	private final String code;
+	private final String displayName;
+
+	RoomType(String code, String displayName) {
+		this.code = code;
+		this.displayName = displayName;
+	}
+
+	public static boolean isValid(String value) {
+		if (value == null) return false;
+		return Arrays.stream(values())
+				.anyMatch(type -> type.name().equalsIgnoreCase(value) || type.code.equalsIgnoreCase(value));
+	}
+
+	public static RoomType fromString(String value) {
+		if (value == null) return CHAT;
+		return Arrays.stream(values())
+				.filter(type -> type.name().equalsIgnoreCase(value) || type.code.equalsIgnoreCase(value))
+				.findFirst()
+				.orElse(CHAT);
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCode.java
@@ -41,6 +41,9 @@ public enum ChattingErrorCode implements DomainErrorCode {
 	GAME_ALREADY_IN_PROGRESS("GAME_004", "이미 게임이 진행 중입니다", 409),
 	NOT_GAME_STARTER("GAME_005", "게임 시작자만 중단할 수 있습니다", 403),
 	GAME_NOT_FOUND("GAME_006", "게임 세션을 찾을 수 없습니다", 404),
+	GAME_NOT_ALLOWED_IN_CHAT_ROOM("GAME_007", "게임은 게임 방에서만 시작할 수 있습니다", 400),
+	GAME_RESTART_NOT_ALLOWED("GAME_008", "게임 진행 중에는 재시작할 수 없습니다", 400),
+	GAME_START_NOT_HOST("GAME_009", "방장만 게임을 시작할 수 있습니다", 403),
 	;
 	
 	private static final String DOMAIN = "CHATTING";

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/ChatRoom.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/ChatRoom.java
@@ -36,7 +36,13 @@ public class ChatRoom {
 
 	// 게임 세션 참조 (게임 상태는 GameSession으로 분리됨)
 	private String activeGameSessionId; // 현재 진행중인 게임 세션 ID (nullable)
-	
+
+	private String type;           // CHAT, GAME (기본값: CHAT)
+	private String gameType;       // CATCHMIND (nullable, GAME 타입일 때만)
+	private GameSettings gameSettings;  // 게임 설정 (nullable)
+	private String status;         // WAITING, PLAYING, FINISHED (기본값: WAITING)
+	private String hostId;         // 방장 userId (createdBy와 별도 관리)
+
 	@DynamoDbPartitionKey
 	@DynamoDbAttribute("PK")
 	public String getPk() {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameSettings.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameSettings.java
@@ -1,0 +1,21 @@
+package com.mzc.secondproject.serverless.domain.chatting.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameSettings {
+	@Builder.Default
+	private Integer maxRounds = 5;
+
+	@Builder.Default
+	private Integer roundTimeLimit = 60;
+
+	@Builder.Default
+	private Boolean autoDeleteOnEnd = false;
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatRoomQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatRoomQueryService.java
@@ -26,11 +26,27 @@ public class ChatRoomQueryService {
 		return roomRepository.findById(roomId);
 	}
 	
-	public PaginatedResult<ChatRoom> getRooms(String level, int limit, String cursor) {
+	public PaginatedResult<ChatRoom> getRooms(String level, int limit, String cursor, String type, String gameType, String status) {
+		PaginatedResult<ChatRoom> roomPage;
 		if (level != null && !level.isEmpty()) {
-			return roomRepository.findByLevelWithPagination(level, limit, cursor);
+			roomPage = roomRepository.findByLevelWithPagination(level, limit, cursor);
+		} else {
+			roomPage = roomRepository.findAllWithPagination(limit, cursor);
 		}
-		return roomRepository.findAllWithPagination(limit, cursor);
+
+		List<ChatRoom> rooms = roomPage.items();
+
+		if (type != null) {
+			rooms = rooms.stream().filter(r -> type.equalsIgnoreCase(r.getType())).toList();
+		}
+		if (gameType != null) {
+			rooms = rooms.stream().filter(r -> gameType.equalsIgnoreCase(r.getGameType())).toList();
+		}
+		if (status != null) {
+			rooms = rooms.stream().filter(r -> status.equalsIgnoreCase(r.getStatus())).toList();
+		}
+
+		return new PaginatedResult<>(rooms, roomPage.nextCursor());
 	}
 	
 	public List<ChatRoom> filterByJoinedUser(List<ChatRoom> rooms, String userId) {

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCodeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/chatting/exception/ChattingErrorCodeSpec.groovy
@@ -40,11 +40,15 @@ class ChattingErrorCodeSpec extends Specification {
         ChattingErrorCode.GAME_NOT_IN_PROGRESS    | "GAME_003"      | 400
         ChattingErrorCode.GAME_ALREADY_IN_PROGRESS| "GAME_004"      | 409
         ChattingErrorCode.NOT_GAME_STARTER        | "GAME_005"      | 403
+        ChattingErrorCode.GAME_NOT_FOUND          | "GAME_006"      | 404
+        ChattingErrorCode.GAME_NOT_ALLOWED_IN_CHAT_ROOM | "GAME_007" | 400
+        ChattingErrorCode.GAME_RESTART_NOT_ALLOWED | "GAME_008"     | 400
+        ChattingErrorCode.GAME_START_NOT_HOST     | "GAME_009"      | 403
     }
 
     def "모든 에러 코드 개수 확인"() {
-        expect: "20개의 에러 코드 존재"
-        ChattingErrorCode.values().length == 20
+        expect: "24개의 에러 코드 존재"
+        ChattingErrorCode.values().length == 24
     }
 
     def "채팅방 관련 에러 코드들 (ROOM_XXX)"() {
@@ -71,5 +75,9 @@ class ChattingErrorCodeSpec extends Specification {
         ChattingErrorCode.GAME_NOT_IN_PROGRESS.getCode().startsWith("GAME_")
         ChattingErrorCode.GAME_ALREADY_IN_PROGRESS.getCode().startsWith("GAME_")
         ChattingErrorCode.NOT_GAME_STARTER.getCode().startsWith("GAME_")
+        ChattingErrorCode.GAME_NOT_FOUND.getCode().startsWith("GAME_")
+        ChattingErrorCode.GAME_NOT_ALLOWED_IN_CHAT_ROOM.getCode().startsWith("GAME_")
+        ChattingErrorCode.GAME_RESTART_NOT_ALLOWED.getCode().startsWith("GAME_")
+        ChattingErrorCode.GAME_START_NOT_HOST.getCode().startsWith("GAME_")
     }
 }

--- a/ServerlessFunction/src/test/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomStatusTest.java
+++ b/ServerlessFunction/src/test/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomStatusTest.java
@@ -1,0 +1,44 @@
+package com.mzc.secondproject.serverless.domain.chatting.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoomStatusTest {
+	@Test
+	void testFromString() {
+		assertEquals(RoomStatus.WAITING, RoomStatus.fromString("waiting"));
+		assertEquals(RoomStatus.WAITING, RoomStatus.fromString("WAITING"));
+		assertEquals(RoomStatus.PLAYING, RoomStatus.fromString("playing"));
+		assertEquals(RoomStatus.PLAYING, RoomStatus.fromString("PLAYING"));
+		assertEquals(RoomStatus.FINISHED, RoomStatus.fromString("finished"));
+		assertEquals(RoomStatus.FINISHED, RoomStatus.fromString("FINISHED"));
+		assertEquals(RoomStatus.WAITING, RoomStatus.fromString(null));
+		assertEquals(RoomStatus.WAITING, RoomStatus.fromString("invalid"));
+	}
+
+	@Test
+	void testIsValid() {
+		assertTrue(RoomStatus.isValid("WAITING"));
+		assertTrue(RoomStatus.isValid("waiting"));
+		assertTrue(RoomStatus.isValid("PLAYING"));
+		assertTrue(RoomStatus.isValid("playing"));
+		assertTrue(RoomStatus.isValid("FINISHED"));
+		assertTrue(RoomStatus.isValid("finished"));
+		assertFalse(RoomStatus.isValid(null));
+		assertFalse(RoomStatus.isValid("invalid"));
+	}
+
+	@Test
+	void testGetCode() {
+		assertEquals("waiting", RoomStatus.WAITING.getCode());
+		assertEquals("playing", RoomStatus.PLAYING.getCode());
+		assertEquals("finished", RoomStatus.FINISHED.getCode());
+	}
+
+	@Test
+	void testGetDisplayName() {
+		assertEquals("대기 중", RoomStatus.WAITING.getDisplayName());
+		assertEquals("게임 중", RoomStatus.PLAYING.getDisplayName());
+		assertEquals("종료됨", RoomStatus.FINISHED.getDisplayName());
+	}
+}

--- a/ServerlessFunction/src/test/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomTypeTest.java
+++ b/ServerlessFunction/src/test/java/com/mzc/secondproject/serverless/domain/chatting/enums/RoomTypeTest.java
@@ -1,0 +1,38 @@
+package com.mzc.secondproject.serverless.domain.chatting.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoomTypeTest {
+	@Test
+	void testFromString() {
+		assertEquals(RoomType.CHAT, RoomType.fromString("chat"));
+		assertEquals(RoomType.CHAT, RoomType.fromString("CHAT"));
+		assertEquals(RoomType.GAME, RoomType.fromString("game"));
+		assertEquals(RoomType.GAME, RoomType.fromString("GAME"));
+		assertEquals(RoomType.CHAT, RoomType.fromString(null));
+		assertEquals(RoomType.CHAT, RoomType.fromString("invalid"));
+	}
+
+	@Test
+	void testIsValid() {
+		assertTrue(RoomType.isValid("CHAT"));
+		assertTrue(RoomType.isValid("chat"));
+		assertTrue(RoomType.isValid("GAME"));
+		assertTrue(RoomType.isValid("game"));
+		assertFalse(RoomType.isValid(null));
+		assertFalse(RoomType.isValid("invalid"));
+	}
+
+	@Test
+	void testGetCode() {
+		assertEquals("chat", RoomType.CHAT.getCode());
+		assertEquals("game", RoomType.GAME.getCode());
+	}
+
+	@Test
+	void testGetDisplayName() {
+		assertEquals("채팅방", RoomType.CHAT.getDisplayName());
+		assertEquals("게임방", RoomType.GAME.getDisplayName());
+	}
+}

--- a/ServerlessFunction/src/test/java/com/mzc/secondproject/serverless/domain/chatting/model/GameSettingsTest.java
+++ b/ServerlessFunction/src/test/java/com/mzc/secondproject/serverless/domain/chatting/model/GameSettingsTest.java
@@ -1,0 +1,54 @@
+package com.mzc.secondproject.serverless.domain.chatting.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GameSettingsTest {
+	@Test
+	void testDefaultValues() {
+		GameSettings settings = GameSettings.builder().build();
+		assertEquals(5, settings.getMaxRounds());
+		assertEquals(60, settings.getRoundTimeLimit());
+		assertFalse(settings.getAutoDeleteOnEnd());
+	}
+
+	@Test
+	void testCustomValues() {
+		GameSettings settings = GameSettings.builder()
+				.maxRounds(10)
+				.roundTimeLimit(90)
+				.autoDeleteOnEnd(true)
+				.build();
+		assertEquals(10, settings.getMaxRounds());
+		assertEquals(90, settings.getRoundTimeLimit());
+		assertTrue(settings.getAutoDeleteOnEnd());
+	}
+
+	@Test
+	void testNoArgsConstructor() {
+		GameSettings settings = new GameSettings();
+		assertEquals(5, settings.getMaxRounds());
+		assertEquals(60, settings.getRoundTimeLimit());
+		assertFalse(settings.getAutoDeleteOnEnd());
+	}
+
+	@Test
+	void testAllArgsConstructor() {
+		GameSettings settings = new GameSettings(10, 90, true);
+		assertEquals(10, settings.getMaxRounds());
+		assertEquals(90, settings.getRoundTimeLimit());
+		assertTrue(settings.getAutoDeleteOnEnd());
+	}
+
+	@Test
+	void testSettersAndGetters() {
+		GameSettings settings = new GameSettings();
+		settings.setMaxRounds(8);
+		settings.setRoundTimeLimit(120);
+		settings.setAutoDeleteOnEnd(true);
+
+		assertEquals(8, settings.getMaxRounds());
+		assertEquals(120, settings.getRoundTimeLimit());
+		assertTrue(settings.getAutoDeleteOnEnd());
+	}
+}


### PR DESCRIPTION
## Summary
- 채팅방과 게임방을 분리하여 게임을 독립적인 카테고리로 운영
- Room 타입 분리 (CHAT/GAME), 방 목록 API 필터 추가
- 게임 재시작 API, 방장 변경 로직, WebSocket 알림 구현

## Changes

### Phase 1 (필수)
- [x] Room 스키마에 type, gameType, gameSettings, status, hostId 필드 추가
- [x] RoomType, RoomStatus enum 생성
- [x] GameSettings 모델 생성
- [x] 방 생성/조회 API에 새 필드 지원
- [x] 방 목록 API에 type, gameType, status 필터 추가
- [x] 게임 시작 시 방 타입 검증 (GAME 타입만 허용)

### Phase 2 (권장)
- [x] 게임 재시작 API (POST /rooms/{roomId}/game/restart)
- [x] 방장 변경 로직 (퇴장 시 자동 이전)
- [x] WebSocket 메시지 타입 추가 (ROOM_STATUS_CHANGE, HOST_CHANGE)

### 에러 코드 추가
- GAME_007: 게임은 게임 방에서만 시작할 수 있습니다
- GAME_008: 게임 진행 중에는 재시작할 수 없습니다
- GAME_009: 방장만 게임을 시작할 수 있습니다

## Test Plan
- [x] RoomType, RoomStatus enum 테스트
- [x] GameSettings 모델 테스트
- [x] ChattingErrorCode 테스트 업데이트
- [x] 전체 테스트 통과 확인 (467 tests)

## Related Issues
- Epic: #440
- Stories: #441, #442, #443, #444, #445, #446
- Tasks: #447, #448, #449, #450, #451, #452, #453, #454