### PR TITLE
refactor(all): DI 패턴 및 전략 패턴 적용 refs #460

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/handler/BadgeHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/handler/BadgeHandler.java
@@ -23,8 +23,18 @@ public class BadgeHandler implements RequestHandler<APIGatewayProxyRequestEvent,
 	private final BadgeService badgeService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public BadgeHandler() {
-		this.badgeService = new BadgeService();
+		this(new BadgeService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public BadgeHandler(BadgeService badgeService) {
+		this.badgeService = badgeService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/repository/BadgeRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/repository/BadgeRepository.java
@@ -6,6 +6,7 @@ import com.mzc.secondproject.serverless.domain.badge.constants.BadgeKey;
 import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -22,9 +23,19 @@ public class BadgeRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<UserBadge> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public BadgeRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(UserBadge.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public BadgeRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(UserBadge.class));
 	}
 	
 	public void save(UserBadge badge) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/service/BadgeService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/service/BadgeService.java
@@ -10,6 +10,9 @@ import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsReposit
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.mzc.secondproject.serverless.domain.badge.strategy.BadgeConditionStrategy;
+import com.mzc.secondproject.serverless.domain.badge.strategy.BadgeConditionStrategyFactory;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,10 +25,20 @@ public class BadgeService {
 	
 	private final BadgeRepository badgeRepository;
 	private final UserStatsRepository userStatsRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public BadgeService() {
-		this.badgeRepository = new BadgeRepository();
-		this.userStatsRepository = new UserStatsRepository();
+		this(new BadgeRepository(), new UserStatsRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public BadgeService(BadgeRepository badgeRepository, UserStatsRepository userStatsRepository) {
+		this.badgeRepository = badgeRepository;
+		this.userStatsRepository = userStatsRepository;
 	}
 	
 	/**
@@ -132,51 +145,16 @@ public class BadgeService {
 	
 	private boolean checkBadgeCondition(BadgeType type, UserStats stats) {
 		if (stats == null) return false;
-		
-		return switch (type.getCategory()) {
-			case "FIRST_STUDY" -> stats.getTestsCompleted() != null && stats.getTestsCompleted() >= 1;
-			case "STREAK" -> stats.getCurrentStreak() != null && stats.getCurrentStreak() >= type.getThreshold();
-			case "WORDS_LEARNED" -> {
-				int total = (stats.getNewWordsLearned() != null ? stats.getNewWordsLearned() : 0)
-						+ (stats.getWordsReviewed() != null ? stats.getWordsReviewed() : 0);
-				yield total >= type.getThreshold();
-			}
-			case "PERFECT_TEST" -> false; // 별도 로직 필요 (테스트 결과에서 체크)
-			case "TESTS_COMPLETED" ->
-					stats.getTestsCompleted() != null && stats.getTestsCompleted() >= type.getThreshold();
-			case "ACCURACY" -> {
-				if (stats.getQuestionsAnswered() == null || stats.getQuestionsAnswered() == 0) yield false;
-				double accuracy = (stats.getCorrectAnswers() * 100.0) / stats.getQuestionsAnswered();
-				yield accuracy >= type.getThreshold();
-			}
-			case "GAMES_PLAYED" -> stats.getGamesPlayed() != null && stats.getGamesPlayed() >= type.getThreshold();
-			case "GAMES_WON" -> stats.getGamesWon() != null && stats.getGamesWon() >= type.getThreshold();
-			case "QUICK_GUESSES" -> stats.getQuickGuesses() != null && stats.getQuickGuesses() >= type.getThreshold();
-			case "PERFECT_DRAWS" -> stats.getPerfectDraws() != null && stats.getPerfectDraws() >= type.getThreshold();
-			case "ALL_BADGES" -> false; // 별도 로직 필요
-			default -> false;
-		};
+
+		BadgeConditionStrategy strategy = BadgeConditionStrategyFactory.getStrategy(type.getCategory());
+		return strategy.checkCondition(type, stats);
 	}
-	
+
 	private int calculateProgress(BadgeType type, UserStats stats) {
 		if (stats == null) return 0;
-		
-		return switch (type.getCategory()) {
-			case "FIRST_STUDY" -> stats.getTestsCompleted() != null && stats.getTestsCompleted() >= 1 ? 1 : 0;
-			case "STREAK" -> stats.getCurrentStreak() != null ? stats.getCurrentStreak() : 0;
-			case "WORDS_LEARNED" -> (stats.getNewWordsLearned() != null ? stats.getNewWordsLearned() : 0)
-					+ (stats.getWordsReviewed() != null ? stats.getWordsReviewed() : 0);
-			case "TESTS_COMPLETED" -> stats.getTestsCompleted() != null ? stats.getTestsCompleted() : 0;
-			case "ACCURACY" -> {
-				if (stats.getQuestionsAnswered() == null || stats.getQuestionsAnswered() == 0) yield 0;
-				yield (int) ((stats.getCorrectAnswers() * 100.0) / stats.getQuestionsAnswered());
-			}
-			case "GAMES_PLAYED" -> stats.getGamesPlayed() != null ? stats.getGamesPlayed() : 0;
-			case "GAMES_WON" -> stats.getGamesWon() != null ? stats.getGamesWon() : 0;
-			case "QUICK_GUESSES" -> stats.getQuickGuesses() != null ? stats.getQuickGuesses() : 0;
-			case "PERFECT_DRAWS" -> stats.getPerfectDraws() != null ? stats.getPerfectDraws() : 0;
-			default -> 0;
-		};
+
+		BadgeConditionStrategy strategy = BadgeConditionStrategyFactory.getStrategy(type.getCategory());
+		return strategy.calculateProgress(type, stats);
 	}
 	
 	public record BadgeInfo(

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/AccuracyStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/AccuracyStrategy.java
@@ -1,0 +1,34 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 정확도 뱃지 조건 전략
+ */
+public class AccuracyStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		double accuracy = calculateAccuracy(stats);
+		return accuracy >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return (int) calculateAccuracy(stats);
+	}
+
+	@Override
+	public String getCategory() {
+		return "ACCURACY";
+	}
+
+	private double calculateAccuracy(UserStats stats) {
+		if (stats.getQuestionsAnswered() == null || stats.getQuestionsAnswered() == 0) {
+			return 0.0;
+		}
+		int correct = stats.getCorrectAnswers() != null ? stats.getCorrectAnswers() : 0;
+		return (correct * 100.0) / stats.getQuestionsAnswered();
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/BadgeConditionStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/BadgeConditionStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 뱃지 조건 확인 전략 인터페이스
+ */
+public interface BadgeConditionStrategy {
+
+	/**
+	 * 뱃지 획득 조건 확인
+	 */
+	boolean checkCondition(BadgeType type, UserStats stats);
+
+	/**
+	 * 현재 진행도 계산
+	 */
+	int calculateProgress(BadgeType type, UserStats stats);
+
+	/**
+	 * 지원하는 카테고리
+	 */
+	String getCategory();
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/BadgeConditionStrategyFactory.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/BadgeConditionStrategyFactory.java
@@ -1,0 +1,40 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 뱃지 조건 전략 팩토리
+ * 카테고리별 전략 인스턴스를 관리하고 제공
+ */
+public class BadgeConditionStrategyFactory {
+
+	private static final Map<String, BadgeConditionStrategy> STRATEGIES = new HashMap<>();
+	private static final BadgeConditionStrategy DEFAULT_STRATEGY = new NoOpStrategy("DEFAULT");
+
+	static {
+		register(new FirstStudyStrategy());
+		register(new StreakStrategy());
+		register(new WordsLearnedStrategy());
+		register(new TestsCompletedStrategy());
+		register(new AccuracyStrategy());
+		register(new GamesPlayedStrategy());
+		register(new GamesWonStrategy());
+		register(new QuickGuessesStrategy());
+		register(new PerfectDrawsStrategy());
+		// 별도 로직이 필요한 카테고리
+		register(new NoOpStrategy("PERFECT_TEST"));
+		register(new NoOpStrategy("ALL_BADGES"));
+	}
+
+	private static void register(BadgeConditionStrategy strategy) {
+		STRATEGIES.put(strategy.getCategory(), strategy);
+	}
+
+	/**
+	 * 카테고리에 해당하는 전략 반환
+	 */
+	public static BadgeConditionStrategy getStrategy(String category) {
+		return STRATEGIES.getOrDefault(category, DEFAULT_STRATEGY);
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/FirstStudyStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/FirstStudyStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 첫 학습 뱃지 조건 전략
+ */
+public class FirstStudyStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getTestsCompleted() != null && stats.getTestsCompleted() >= 1;
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return (stats.getTestsCompleted() != null && stats.getTestsCompleted() >= 1) ? 1 : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "FIRST_STUDY";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/GamesPlayedStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/GamesPlayedStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 게임 플레이 횟수 뱃지 조건 전략
+ */
+public class GamesPlayedStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getGamesPlayed() != null && stats.getGamesPlayed() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getGamesPlayed() != null ? stats.getGamesPlayed() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "GAMES_PLAYED";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/GamesWonStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/GamesWonStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 게임 승리 횟수 뱃지 조건 전략
+ */
+public class GamesWonStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getGamesWon() != null && stats.getGamesWon() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getGamesWon() != null ? stats.getGamesWon() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "GAMES_WON";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NoOpStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NoOpStrategy.java
@@ -1,0 +1,32 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 별도 로직이 필요한 뱃지용 No-Op 전략
+ * PERFECT_TEST, ALL_BADGES 등은 별도 로직에서 처리
+ */
+public class NoOpStrategy implements BadgeConditionStrategy {
+
+	private final String category;
+
+	public NoOpStrategy(String category) {
+		this.category = category;
+	}
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return false;
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return category;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/PerfectDrawsStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/PerfectDrawsStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 완벽한 출제 뱃지 조건 전략
+ */
+public class PerfectDrawsStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getPerfectDraws() != null && stats.getPerfectDraws() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getPerfectDraws() != null ? stats.getPerfectDraws() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "PERFECT_DRAWS";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/QuickGuessesStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/QuickGuessesStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 빠른 정답 뱃지 조건 전략
+ */
+public class QuickGuessesStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getQuickGuesses() != null && stats.getQuickGuesses() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getQuickGuesses() != null ? stats.getQuickGuesses() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "QUICK_GUESSES";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/StreakStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/StreakStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 연속 학습 뱃지 조건 전략
+ */
+public class StreakStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getCurrentStreak() != null && stats.getCurrentStreak() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getCurrentStreak() != null ? stats.getCurrentStreak() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "STREAK";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/TestsCompletedStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/TestsCompletedStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 테스트 완료 횟수 뱃지 조건 전략
+ */
+public class TestsCompletedStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getTestsCompleted() != null && stats.getTestsCompleted() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getTestsCompleted() != null ? stats.getTestsCompleted() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "TESTS_COMPLETED";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/WordsLearnedStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/WordsLearnedStrategy.java
@@ -1,0 +1,32 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 단어 학습량 뱃지 조건 전략
+ */
+public class WordsLearnedStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		int total = getTotalWordsLearned(stats);
+		return total >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return getTotalWordsLearned(stats);
+	}
+
+	@Override
+	public String getCategory() {
+		return "WORDS_LEARNED";
+	}
+
+	private int getTotalWordsLearned(UserStats stats) {
+		int newWords = stats.getNewWordsLearned() != null ? stats.getNewWordsLearned() : 0;
+		int reviewedWords = stats.getWordsReviewed() != null ? stats.getWordsReviewed() : 0;
+		return newWords + reviewedWords;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatMessageHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatMessageHandler.java
@@ -31,9 +31,19 @@ public class ChatMessageHandler implements RequestHandler<APIGatewayProxyRequest
 	private final ChatRoomRepository chatRoomRepository;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatMessageHandler() {
-		this.chatMessageService = new ChatMessageService();
-		this.chatRoomRepository = new ChatRoomRepository();
+		this(new ChatMessageService(), new ChatRoomRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatMessageHandler(ChatMessageService chatMessageService, ChatRoomRepository chatRoomRepository) {
+		this.chatMessageService = chatMessageService;
+		this.chatRoomRepository = chatRoomRepository;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatRoomHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatRoomHandler.java
@@ -34,9 +34,19 @@ public class ChatRoomHandler implements RequestHandler<APIGatewayProxyRequestEve
 	private final ChatRoomQueryService queryService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatRoomHandler() {
-		this.commandService = new ChatRoomCommandService();
-		this.queryService = new ChatRoomQueryService();
+		this(new ChatRoomCommandService(), new ChatRoomQueryService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatRoomHandler(ChatRoomCommandService commandService, ChatRoomQueryService queryService) {
+		this.commandService = commandService;
+		this.queryService = queryService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatVoiceHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/ChatVoiceHandler.java
@@ -28,9 +28,19 @@ public class ChatVoiceHandler implements RequestHandler<APIGatewayProxyRequestEv
 	private final PollyService pollyService;
 	private final ChatMessageRepository messageRepository;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatVoiceHandler() {
-		this.pollyService = new PollyService(BUCKET_NAME, "voice/");
-		this.messageRepository = new ChatMessageRepository();
+		this(new PollyService(BUCKET_NAME, "voice/"), new ChatMessageRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatVoiceHandler(PollyService pollyService, ChatMessageRepository messageRepository) {
+		this.pollyService = pollyService;
+		this.messageRepository = messageRepository;
 	}
 	
 	@Override

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameAutoCloseHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameAutoCloseHandler.java
@@ -31,10 +31,21 @@ public class GameAutoCloseHandler implements RequestHandler<Map<String, String>,
 	private final ConnectionRepository connectionRepository;
 	private final WebSocketBroadcaster broadcaster;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameAutoCloseHandler() {
-		this.gameService = new GameService();
-		this.connectionRepository = new ConnectionRepository();
-		this.broadcaster = new WebSocketBroadcaster();
+		this(new GameService(), new ConnectionRepository(), new WebSocketBroadcaster());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameAutoCloseHandler(GameService gameService, ConnectionRepository connectionRepository,
+								WebSocketBroadcaster broadcaster) {
+		this.gameService = gameService;
+		this.connectionRepository = connectionRepository;
+		this.broadcaster = broadcaster;
 	}
 
 	@Override

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameHandler.java
@@ -38,11 +38,22 @@ public class GameHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 	private final WebSocketBroadcaster broadcaster;
 	private final HandlerRouter router;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameHandler() {
-		this.gameService = new GameService();
-		this.gameSessionRepository = new GameSessionRepository();
-		this.connectionRepository = new ConnectionRepository();
-		this.broadcaster = new WebSocketBroadcaster();
+		this(new GameService(), new GameSessionRepository(), new ConnectionRepository(), new WebSocketBroadcaster());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameHandler(GameService gameService, GameSessionRepository gameSessionRepository,
+					   ConnectionRepository connectionRepository, WebSocketBroadcaster broadcaster) {
+		this.gameService = gameService;
+		this.gameSessionRepository = gameSessionRepository;
+		this.connectionRepository = connectionRepository;
+		this.broadcaster = broadcaster;
 		this.router = initRouter();
 	}
 

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameSessionHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/handler/GameSessionHandler.java
@@ -37,11 +37,22 @@ public class GameSessionHandler implements RequestHandler<APIGatewayProxyRequest
 	private final WebSocketBroadcaster broadcaster;
 	private final HandlerRouter router;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameSessionHandler() {
-		this.gameService = new GameService();
-		this.gameSessionRepository = new GameSessionRepository();
-		this.connectionRepository = new ConnectionRepository();
-		this.broadcaster = new WebSocketBroadcaster();
+		this(new GameService(), new GameSessionRepository(), new ConnectionRepository(), new WebSocketBroadcaster());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameSessionHandler(GameService gameService, GameSessionRepository gameSessionRepository,
+							  ConnectionRepository connectionRepository, WebSocketBroadcaster broadcaster) {
+		this.gameService = gameService;
+		this.gameSessionRepository = gameSessionRepository;
+		this.connectionRepository = connectionRepository;
+		this.broadcaster = broadcaster;
 		this.router = initRouter();
 	}
 

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatMessageRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatMessageRepository.java
@@ -7,6 +7,7 @@ import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -25,9 +26,19 @@ public class ChatMessageRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<ChatMessage> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatMessageRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(ChatMessage.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatMessageRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(ChatMessage.class));
 	}
 	
 	public ChatMessage save(ChatMessage message) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatRoomRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ChatRoomRepository.java
@@ -7,6 +7,7 @@ import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.chatting.model.ChatRoom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -28,9 +29,19 @@ public class ChatRoomRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<ChatRoom> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatRoomRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(ChatRoom.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatRoomRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(ChatRoom.class));
 	}
 	
 	public ChatRoom save(ChatRoom room) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ConnectionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/ConnectionRepository.java
@@ -5,6 +5,7 @@ import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.chatting.model.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -22,9 +23,19 @@ public class ConnectionRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<Connection> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ConnectionRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(Connection.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ConnectionRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(Connection.class));
 	}
 	
 	public Connection save(Connection connection) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameRoundRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameRoundRepository.java
@@ -29,8 +29,18 @@ public class GameRoundRepository {
 	private final DynamoDbEnhancedClient enhancedClient;
 	private final DynamoDbTable<GameRound> table;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameRoundRepository() {
-		this.enhancedClient = AwsClients.dynamoDbEnhanced();
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameRoundRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.enhancedClient = enhancedClient;
 		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(GameRound.class));
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameSessionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/GameSessionRepository.java
@@ -5,6 +5,7 @@ import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.chatting.model.GameSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -30,8 +31,18 @@ public class GameSessionRepository {
 
 	private final DynamoDbTable<GameSession> table;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameSessionRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(GameSession.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameSessionRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(GameSession.class));
 	}
 
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/RoomTokenRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/repository/RoomTokenRepository.java
@@ -5,6 +5,7 @@ import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.chatting.model.RoomToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -17,9 +18,19 @@ public class RoomTokenRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<RoomToken> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public RoomTokenRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(RoomToken.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public RoomTokenRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(RoomToken.class));
 	}
 	
 	public RoomToken save(RoomToken roomToken) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatMessageService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatMessageService.java
@@ -13,9 +13,19 @@ public class ChatMessageService {
 	private static final Logger logger = LoggerFactory.getLogger(ChatMessageService.class);
 	
 	private final ChatMessageRepository repository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatMessageService() {
-		this.repository = new ChatMessageRepository();
+		this(new ChatMessageRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatMessageService(ChatMessageRepository repository) {
+		this.repository = repository;
 	}
 	
 	public ChatMessage saveMessage(ChatMessage message) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatRoomCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatRoomCommandService.java
@@ -37,12 +37,27 @@ public class ChatRoomCommandService {
 	private final WebSocketBroadcaster broadcaster;
 	private final UserRepository userRepository;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatRoomCommandService() {
-		this.roomRepository = new ChatRoomRepository();
-		this.roomTokenService = new RoomTokenService();
-		this.connectionRepository = new ConnectionRepository();
-		this.broadcaster = new WebSocketBroadcaster();
-		this.userRepository = new UserRepository();
+		this(new ChatRoomRepository(), new RoomTokenService(), new ConnectionRepository(),
+				new WebSocketBroadcaster(), new UserRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatRoomCommandService(ChatRoomRepository roomRepository,
+	                              RoomTokenService roomTokenService,
+	                              ConnectionRepository connectionRepository,
+	                              WebSocketBroadcaster broadcaster,
+	                              UserRepository userRepository) {
+		this.roomRepository = roomRepository;
+		this.roomTokenService = roomTokenService;
+		this.connectionRepository = connectionRepository;
+		this.broadcaster = broadcaster;
+		this.userRepository = userRepository;
 	}
 	
 	public ChatRoom createRoom(String name, String description, String level, Integer maxMembers,

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatRoomQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/ChatRoomQueryService.java
@@ -22,9 +22,19 @@ public class ChatRoomQueryService {
 	private final ChatRoomRepository roomRepository;
 	private final UserRepository userRepository;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ChatRoomQueryService() {
-		this.roomRepository = new ChatRoomRepository();
-		this.userRepository = new UserRepository();
+		this(new ChatRoomRepository(), new UserRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ChatRoomQueryService(ChatRoomRepository roomRepository, UserRepository userRepository) {
+		this.roomRepository = roomRepository;
+		this.userRepository = userRepository;
 	}
 	
 	public Optional<ChatRoom> getRoom(String roomId) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/CommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/CommandService.java
@@ -23,10 +23,22 @@ public class CommandService {
 	private final GameSessionRepository gameSessionRepository;
 	private final GameService gameService;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public CommandService() {
-		this.connectionRepository = new ConnectionRepository();
-		this.gameSessionRepository = new GameSessionRepository();
-		this.gameService = new GameService();
+		this(new ConnectionRepository(), new GameSessionRepository(), new GameService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public CommandService(ConnectionRepository connectionRepository,
+	                      GameSessionRepository gameSessionRepository,
+	                      GameService gameService) {
+		this.connectionRepository = connectionRepository;
+		this.gameSessionRepository = gameSessionRepository;
+		this.gameService = gameService;
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameSchedulerClient.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameSchedulerClient.java
@@ -25,10 +25,22 @@ public class GameSchedulerClient {
 	private final String targetLambdaArn;
 	private final String roleArn;
 
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameSchedulerClient() {
-		this.schedulerClient = SchedulerClient.create();
-		this.targetLambdaArn = EnvConfig.getOrDefault("GAME_AUTO_CLOSE_LAMBDA_ARN", null);
-		this.roleArn = EnvConfig.getOrDefault("SCHEDULER_ROLE_ARN", null);
+		this(SchedulerClient.create(),
+				EnvConfig.getOrDefault("GAME_AUTO_CLOSE_LAMBDA_ARN", null),
+				EnvConfig.getOrDefault("SCHEDULER_ROLE_ARN", null));
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameSchedulerClient(SchedulerClient schedulerClient, String targetLambdaArn, String roleArn) {
+		this.schedulerClient = schedulerClient;
+		this.targetLambdaArn = targetLambdaArn;
+		this.roleArn = roleArn;
 	}
 
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameStatsService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/GameStatsService.java
@@ -23,11 +23,23 @@ public class GameStatsService {
 	private final UserStatsRepository userStatsRepository;
 	private final GameRoundRepository gameRoundRepository;
 	private final BadgeService badgeService;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GameStatsService() {
-		this.userStatsRepository = new UserStatsRepository();
-		this.gameRoundRepository = new GameRoundRepository();
-		this.badgeService = new BadgeService();
+		this(new UserStatsRepository(), new GameRoundRepository(), new BadgeService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GameStatsService(UserStatsRepository userStatsRepository,
+	                        GameRoundRepository gameRoundRepository,
+	                        BadgeService badgeService) {
+		this.userStatsRepository = userStatsRepository;
+		this.gameRoundRepository = gameRoundRepository;
+		this.badgeService = badgeService;
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/RoomTokenService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/service/RoomTokenService.java
@@ -19,9 +19,19 @@ public class RoomTokenService {
 	private static final Logger logger = LoggerFactory.getLogger(RoomTokenService.class);
 	
 	private final RoomTokenRepository tokenRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public RoomTokenService() {
-		this.tokenRepository = new RoomTokenRepository();
+		this(new RoomTokenRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public RoomTokenService(RoomTokenRepository tokenRepository) {
+		this.tokenRepository = tokenRepository;
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/handler/GrammarHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/handler/GrammarHandler.java
@@ -30,10 +30,21 @@ public class GrammarHandler implements RequestHandler<APIGatewayProxyRequestEven
 	private final GrammarSessionQueryService sessionQueryService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GrammarHandler() {
-		this.grammarCheckService = new GrammarCheckService();
-		this.conversationService = new GrammarConversationService();
-		this.sessionQueryService = new GrammarSessionQueryService();
+		this(new GrammarCheckService(), new GrammarConversationService(), new GrammarSessionQueryService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GrammarHandler(GrammarCheckService grammarCheckService, GrammarConversationService conversationService,
+						  GrammarSessionQueryService sessionQueryService) {
+		this.grammarCheckService = grammarCheckService;
+		this.conversationService = conversationService;
+		this.sessionQueryService = sessionQueryService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarConnectionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarConnectionRepository.java
@@ -5,6 +5,7 @@ import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.domain.grammar.model.GrammarConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -20,12 +21,19 @@ public class GrammarConnectionRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("CHAT_TABLE_NAME");
 	
 	private final DynamoDbTable<GrammarConnection> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GrammarConnectionRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(
-				TABLE_NAME,
-				TableSchema.fromBean(GrammarConnection.class)
-		);
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GrammarConnectionRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(GrammarConnection.class));
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarSessionRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/grammar/repository/GrammarSessionRepository.java
@@ -9,6 +9,7 @@ import com.mzc.secondproject.serverless.domain.grammar.model.GrammarMessage;
 import com.mzc.secondproject.serverless.domain.grammar.model.GrammarSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -28,10 +29,20 @@ public class GrammarSessionRepository {
 	
 	private final DynamoDbTable<GrammarSession> sessionTable;
 	private final DynamoDbTable<GrammarMessage> messageTable;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public GrammarSessionRepository() {
-		this.sessionTable = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(GrammarSession.class));
-		this.messageTable = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(GrammarMessage.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public GrammarSessionRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.sessionTable = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(GrammarSession.class));
+		this.messageTable = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(GrammarMessage.class));
 	}
 	
 	// ============ Session CRUD ============

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/ScheduledStatsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/ScheduledStatsHandler.java
@@ -31,8 +31,18 @@ public class ScheduledStatsHandler implements RequestHandler<ScheduledEvent, Str
 	
 	private final UserStatsRepository userStatsRepository;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public ScheduledStatsHandler() {
-		this.userStatsRepository = new UserStatsRepository();
+		this(new UserStatsRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public ScheduledStatsHandler(UserStatsRepository userStatsRepository) {
+		this.userStatsRepository = userStatsRepository;
 	}
 	
 	@Override

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/StatsStreamHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/StatsStreamHandler.java
@@ -27,9 +27,19 @@ public class StatsStreamHandler implements RequestHandler<DynamodbEvent, Void> {
 	private final UserStatsRepository userStatsRepository;
 	private final BadgeService badgeService;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public StatsStreamHandler() {
-		this.userStatsRepository = new UserStatsRepository();
-		this.badgeService = new BadgeService();
+		this(new UserStatsRepository(), new BadgeService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public StatsStreamHandler(UserStatsRepository userStatsRepository, BadgeService badgeService) {
+		this.userStatsRepository = userStatsRepository;
+		this.badgeService = badgeService;
 	}
 	
 	@Override

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/UserStatsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/handler/UserStatsHandler.java
@@ -31,9 +31,19 @@ public class UserStatsHandler implements RequestHandler<APIGatewayProxyRequestEv
 	private final DailyStudyRepository dailyStudyRepository;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public UserStatsHandler() {
-		this.statsRepository = new UserStatsRepository();
-		this.dailyStudyRepository = new DailyStudyRepository();
+		this(new UserStatsRepository(), new DailyStudyRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public UserStatsHandler(UserStatsRepository statsRepository, DailyStudyRepository dailyStudyRepository) {
+		this.statsRepository = statsRepository;
+		this.dailyStudyRepository = dailyStudyRepository;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/repository/UserStatsRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/repository/UserStatsRepository.java
@@ -8,6 +8,7 @@ import com.mzc.secondproject.serverless.domain.stats.constants.StatsKey;
 import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -32,9 +33,19 @@ public class UserStatsRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<UserStats> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public UserStatsRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(UserStats.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public UserStatsRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(UserStats.class));
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/service/StatsService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/service/StatsService.java
@@ -17,9 +17,19 @@ public class StatsService {
 	private static final Logger logger = LoggerFactory.getLogger(StatsService.class);
 	
 	private final UserStatsRepository userStatsRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public StatsService() {
-		this.userStatsRepository = new UserStatsRepository();
+		this(new UserStatsRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public StatsService(UserStatsRepository userStatsRepository) {
+		this.userStatsRepository = userStatsRepository;
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/DailyStudyHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/DailyStudyHandler.java
@@ -24,9 +24,19 @@ public class DailyStudyHandler implements RequestHandler<APIGatewayProxyRequestE
 	private final DailyStudyQueryService queryService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public DailyStudyHandler() {
-		this.commandService = new DailyStudyCommandService();
-		this.queryService = new DailyStudyQueryService();
+		this(new DailyStudyCommandService(), new DailyStudyQueryService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public DailyStudyHandler(DailyStudyCommandService commandService, DailyStudyQueryService queryService) {
+		this.commandService = commandService;
+		this.queryService = queryService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatisticsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatisticsHandler.java
@@ -21,8 +21,18 @@ public class StatisticsHandler implements RequestHandler<SQSEvent, Void> {
 	
 	private final StatisticsService statisticsService;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public StatisticsHandler() {
-		this.statisticsService = new StatisticsService();
+		this(new StatisticsService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public StatisticsHandler(StatisticsService statisticsService) {
+		this.statisticsService = statisticsService;
 	}
 	
 	@Override

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/StatsHandler.java
@@ -21,8 +21,18 @@ public class StatsHandler implements RequestHandler<APIGatewayProxyRequestEvent,
 	private final StatsService statsService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public StatsHandler() {
-		this.statsService = new StatsService();
+		this(new StatsService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public StatsHandler(StatsService statsService) {
+		this.statsService = statsService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/TestHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/TestHandler.java
@@ -29,9 +29,19 @@ public class TestHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 	private final TestQueryService queryService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public TestHandler() {
-		this.commandService = new TestCommandService();
-		this.queryService = new TestQueryService();
+		this(new TestCommandService(), new TestQueryService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public TestHandler(TestCommandService commandService, TestQueryService queryService) {
+		this.commandService = commandService;
+		this.queryService = queryService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/UserWordHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/UserWordHandler.java
@@ -31,9 +31,19 @@ public class UserWordHandler implements RequestHandler<APIGatewayProxyRequestEve
 	private final UserWordQueryService queryService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public UserWordHandler() {
-		this.commandService = new UserWordCommandService();
-		this.queryService = new UserWordQueryService();
+		this(new UserWordCommandService(), new UserWordQueryService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public UserWordHandler(UserWordCommandService commandService, UserWordQueryService queryService) {
+		this.commandService = commandService;
+		this.queryService = queryService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/VoiceHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/VoiceHandler.java
@@ -28,9 +28,19 @@ public class VoiceHandler implements RequestHandler<APIGatewayProxyRequestEvent,
 	private final WordRepository wordRepository;
 	private final PollyService pollyService;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public VoiceHandler() {
-		this.wordRepository = new WordRepository();
-		this.pollyService = new PollyService(BUCKET_NAME, "vocab/voice/");
+		this(new WordRepository(), new PollyService(BUCKET_NAME, "vocab/voice/"));
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public VoiceHandler(WordRepository wordRepository, PollyService pollyService) {
+		this.wordRepository = wordRepository;
+		this.pollyService = pollyService;
 	}
 	
 	@Override

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/WordGroupHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/WordGroupHandler.java
@@ -28,9 +28,19 @@ public class WordGroupHandler implements RequestHandler<APIGatewayProxyRequestEv
 	private final WordGroupQueryService queryService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordGroupHandler() {
-		this.commandService = new WordGroupCommandService();
-		this.queryService = new WordGroupQueryService();
+		this(new WordGroupCommandService(), new WordGroupQueryService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordGroupHandler(WordGroupCommandService commandService, WordGroupQueryService queryService) {
+		this.commandService = commandService;
+		this.queryService = queryService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/WordHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/handler/WordHandler.java
@@ -33,9 +33,19 @@ public class WordHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 	private final WordQueryService queryService;
 	private final HandlerRouter router;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordHandler() {
-		this.commandService = new WordCommandService();
-		this.queryService = new WordQueryService();
+		this(new WordCommandService(), new WordQueryService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordHandler(WordCommandService commandService, WordQueryService queryService) {
+		this.commandService = commandService;
+		this.queryService = queryService;
 		this.router = initRouter();
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/DailyStudyRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/DailyStudyRepository.java
@@ -7,6 +7,7 @@ import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.DailyStudy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -26,9 +27,19 @@ public class DailyStudyRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<DailyStudy> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public DailyStudyRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(DailyStudy.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public DailyStudyRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(DailyStudy.class));
 	}
 	
 	public DailyStudy save(DailyStudy dailyStudy) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/TestResultRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/TestResultRepository.java
@@ -7,6 +7,7 @@ import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.TestResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
@@ -25,9 +26,19 @@ public class TestResultRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<TestResult> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public TestResultRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(TestResult.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public TestResultRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(TestResult.class));
 	}
 	
 	public TestResult save(TestResult testResult) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/UserWordRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/UserWordRepository.java
@@ -22,9 +22,19 @@ public class UserWordRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<UserWord> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public UserWordRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(UserWord.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public UserWordRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(UserWord.class));
 	}
 	
 	public UserWord save(UserWord userWord) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordGroupRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordGroupRepository.java
@@ -7,6 +7,7 @@ import com.mzc.secondproject.serverless.common.util.CursorUtil;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.WordGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -24,9 +25,19 @@ public class WordGroupRepository {
 	private static final String TABLE_NAME = EnvConfig.getRequired("VOCAB_TABLE_NAME");
 	
 	private final DynamoDbTable<WordGroup> table;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordGroupRepository() {
-		this.table = AwsClients.dynamoDbEnhanced().table(TABLE_NAME, TableSchema.fromBean(WordGroup.class));
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordGroupRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(WordGroup.class));
 	}
 	
 	public WordGroup save(WordGroup wordGroup) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/WordRepository.java
@@ -24,8 +24,18 @@ public class WordRepository {
 	private final DynamoDbEnhancedClient enhancedClient;
 	private final DynamoDbTable<Word> table;
 	
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordRepository() {
-		this.enhancedClient = AwsClients.dynamoDbEnhanced();
+		this(AwsClients.dynamoDbEnhanced());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordRepository(DynamoDbEnhancedClient enhancedClient) {
+		this.enhancedClient = enhancedClient;
 		this.table = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(Word.class));
 	}
 	

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
@@ -34,13 +34,28 @@ public class DailyStudyCommandService {
 	private final WordRepository wordRepository;
 	private final UserStatsRepository userStatsRepository;
 	private final BadgeService badgeService;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public DailyStudyCommandService() {
-		this.dailyStudyRepository = new DailyStudyRepository();
-		this.userWordRepository = new UserWordRepository();
-		this.wordRepository = new WordRepository();
-		this.userStatsRepository = new UserStatsRepository();
-		this.badgeService = new BadgeService();
+		this(new DailyStudyRepository(), new UserWordRepository(), new WordRepository(),
+				new UserStatsRepository(), new BadgeService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public DailyStudyCommandService(DailyStudyRepository dailyStudyRepository,
+	                                UserWordRepository userWordRepository,
+	                                WordRepository wordRepository,
+	                                UserStatsRepository userStatsRepository,
+	                                BadgeService badgeService) {
+		this.dailyStudyRepository = dailyStudyRepository;
+		this.userWordRepository = userWordRepository;
+		this.wordRepository = wordRepository;
+		this.userStatsRepository = userStatsRepository;
+		this.badgeService = badgeService;
 	}
 	
 	public DailyStudyResult getDailyWords(String userId, String level) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyQueryService.java
@@ -19,10 +19,20 @@ public class DailyStudyQueryService {
 	
 	private final DailyStudyRepository dailyStudyRepository;
 	private final WordRepository wordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public DailyStudyQueryService() {
-		this.dailyStudyRepository = new DailyStudyRepository();
-		this.wordRepository = new WordRepository();
+		this(new DailyStudyRepository(), new WordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public DailyStudyQueryService(DailyStudyRepository dailyStudyRepository, WordRepository wordRepository) {
+		this.dailyStudyRepository = dailyStudyRepository;
+		this.wordRepository = wordRepository;
 	}
 	
 	public Optional<DailyStudy> getDailyStudy(String userId, String date) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/StatisticsService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/StatisticsService.java
@@ -16,9 +16,19 @@ public class StatisticsService {
 	private static final Logger logger = LoggerFactory.getLogger(StatisticsService.class);
 	
 	private final UserWordRepository userWordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public StatisticsService() {
-		this.userWordRepository = new UserWordRepository();
+		this(new UserWordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public StatisticsService(UserWordRepository userWordRepository) {
+		this.userWordRepository = userWordRepository;
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/StatsService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/StatsService.java
@@ -24,12 +24,26 @@ public class StatsService {
 	private final DailyStudyRepository dailyStudyRepository;
 	private final TestResultRepository testResultRepository;
 	private final WordRepository wordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public StatsService() {
-		this.userWordRepository = new UserWordRepository();
-		this.dailyStudyRepository = new DailyStudyRepository();
-		this.testResultRepository = new TestResultRepository();
-		this.wordRepository = new WordRepository();
+		this(new UserWordRepository(), new DailyStudyRepository(),
+				new TestResultRepository(), new WordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public StatsService(UserWordRepository userWordRepository,
+	                    DailyStudyRepository dailyStudyRepository,
+	                    TestResultRepository testResultRepository,
+	                    WordRepository wordRepository) {
+		this.userWordRepository = userWordRepository;
+		this.dailyStudyRepository = dailyStudyRepository;
+		this.testResultRepository = testResultRepository;
+		this.wordRepository = wordRepository;
 	}
 	
 	public Map<String, Object> getOverallStats(String userId) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestCommandService.java
@@ -33,12 +33,26 @@ public class TestCommandService {
 	private final DailyStudyRepository dailyStudyRepository;
 	private final WordRepository wordRepository;
 	private final UserWordCommandService userWordCommandService;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public TestCommandService() {
-		this.testResultRepository = new TestResultRepository();
-		this.dailyStudyRepository = new DailyStudyRepository();
-		this.wordRepository = new WordRepository();
-		this.userWordCommandService = new UserWordCommandService();
+		this(new TestResultRepository(), new DailyStudyRepository(),
+				new WordRepository(), new UserWordCommandService());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public TestCommandService(TestResultRepository testResultRepository,
+	                          DailyStudyRepository dailyStudyRepository,
+	                          WordRepository wordRepository,
+	                          UserWordCommandService userWordCommandService) {
+		this.testResultRepository = testResultRepository;
+		this.dailyStudyRepository = dailyStudyRepository;
+		this.wordRepository = wordRepository;
+		this.userWordCommandService = userWordCommandService;
 	}
 	
 	public StartTestResult startTest(String userId, String testType) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/TestQueryService.java
@@ -19,10 +19,20 @@ public class TestQueryService {
 	
 	private final TestResultRepository testResultRepository;
 	private final WordRepository wordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public TestQueryService() {
-		this.testResultRepository = new TestResultRepository();
-		this.wordRepository = new WordRepository();
+		this(new TestResultRepository(), new WordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public TestQueryService(TestResultRepository testResultRepository, WordRepository wordRepository) {
+		this.testResultRepository = testResultRepository;
+		this.wordRepository = wordRepository;
 	}
 	
 	public PaginatedResult<TestResult> getTestResults(String userId, int limit, String cursor) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/UserWordCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/UserWordCommandService.java
@@ -25,9 +25,19 @@ public class UserWordCommandService {
 	private static final Logger logger = LoggerFactory.getLogger(UserWordCommandService.class);
 	
 	private final UserWordRepository userWordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public UserWordCommandService() {
-		this.userWordRepository = new UserWordRepository();
+		this(new UserWordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public UserWordCommandService(UserWordRepository userWordRepository) {
+		this.userWordRepository = userWordRepository;
 	}
 	
 	public UserWord updateUserWord(String userId, String wordId, boolean isCorrect) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/UserWordQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/UserWordQueryService.java
@@ -20,10 +20,20 @@ public class UserWordQueryService {
 	
 	private final UserWordRepository userWordRepository;
 	private final WordRepository wordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public UserWordQueryService() {
-		this.userWordRepository = new UserWordRepository();
-		this.wordRepository = new WordRepository();
+		this(new UserWordRepository(), new WordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public UserWordQueryService(UserWordRepository userWordRepository, WordRepository wordRepository) {
+		this.userWordRepository = userWordRepository;
+		this.wordRepository = wordRepository;
 	}
 	
 	public UserWordsResult getUserWords(String userId, String status, String bookmarked,

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordCommandService.java
@@ -19,9 +19,19 @@ public class WordCommandService {
 	private static final Logger logger = LoggerFactory.getLogger(WordCommandService.class);
 	
 	private final WordRepository wordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordCommandService() {
-		this.wordRepository = new WordRepository();
+		this(new WordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordCommandService(WordRepository wordRepository) {
+		this.wordRepository = wordRepository;
 	}
 	
 	public Word createWord(String english, String korean, String example, String level, String category) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordGroupCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordGroupCommandService.java
@@ -20,9 +20,19 @@ public class WordGroupCommandService {
 	private static final Logger logger = LoggerFactory.getLogger(WordGroupCommandService.class);
 	
 	private final WordGroupRepository wordGroupRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordGroupCommandService() {
-		this.wordGroupRepository = new WordGroupRepository();
+		this(new WordGroupRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordGroupCommandService(WordGroupRepository wordGroupRepository) {
+		this.wordGroupRepository = wordGroupRepository;
 	}
 	
 	public WordGroup createGroup(String userId, String groupName, String description) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordGroupQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordGroupQueryService.java
@@ -20,10 +20,20 @@ public class WordGroupQueryService {
 	
 	private final WordGroupRepository wordGroupRepository;
 	private final WordRepository wordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordGroupQueryService() {
-		this.wordGroupRepository = new WordGroupRepository();
-		this.wordRepository = new WordRepository();
+		this(new WordGroupRepository(), new WordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordGroupQueryService(WordGroupRepository wordGroupRepository, WordRepository wordRepository) {
+		this.wordGroupRepository = wordGroupRepository;
+		this.wordRepository = wordRepository;
 	}
 	
 	public PaginatedResult<WordGroup> getGroups(String userId, int limit, String cursor) {

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/WordQueryService.java
@@ -17,9 +17,19 @@ public class WordQueryService {
 	private static final Logger logger = LoggerFactory.getLogger(WordQueryService.class);
 	
 	private final WordRepository wordRepository;
-	
+
+	/**
+	 * 기본 생성자 (Lambda에서 사용)
+	 */
 	public WordQueryService() {
-		this.wordRepository = new WordRepository();
+		this(new WordRepository());
+	}
+
+	/**
+	 * 의존성 주입 생성자 (테스트 용이성)
+	 */
+	public WordQueryService(WordRepository wordRepository) {
+		this.wordRepository = wordRepository;
 	}
 	
 	public Optional<Word> getWord(String wordId) {


### PR DESCRIPTION
## 목적

- 테스트 용이성 향상을 위한 DI(Dependency Injection) 패턴 적용
- BadgeService의 복잡한 switch 문을 Strategy 패턴으로 리팩토링
- refs #460

## 변경 요약

### 핵심 변경
- Repository, Service, Handler 클래스에 DI 생성자 추가
- BadgeService에 Strategy 패턴 적용 (뱃지 조건 검증 로직 분리)

### 주요 파일/모듈
- **Repository** (14개): WordRepository, UserWordRepository, DailyStudyRepository 등
- **Service** (19개): WordCommandService, ChatRoomCommandService, BadgeService 등
- **Handler** (18개): WordHandler, ChatRoomHandler, GrammarHandler 등
- **Strategy** (12개 신규): BadgeConditionStrategy 인터페이스 및 구현체

## 수용 기준 검증

- [x] AC1: 모든 Repository에 DI 생성자 추가
- [x] AC2: 모든 Service에 DI 생성자 추가
- [x] AC3: 모든 Handler에 DI 생성자 추가
- [x] AC4: BadgeService Strategy 패턴 적용
- [x] AC5: 빌드 성공 확인

## 브레이킹/마이그레이션

- 없음 (기존 기본 생성자 유지, DI 생성자 추가만)

## 테스트

- Gradle 빌드 성공 확인 (`./gradlew compileJava`)
- 기존 동작 변경 없음 (기본 생성자가 DI 생성자 호출)

## 참조

- refs #460