### PR TITLE
feat(news): 뉴스 학습 배지 시스템 구현 (#473)

### DIFF
--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/enums/BadgeType.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/enums/BadgeType.java
@@ -31,7 +31,31 @@ public enum BadgeType {
 	PERFECT_DRAWER("완벽한 출제자", "출제 시 전원이 정답을 맞췄습니다", "perfect_drawer.png", "PERFECT_DRAWS", 1),
 	
 	// 특별
-	MASTER("학습 마스터", "모든 업적을 달성했습니다", "master.png", "ALL_BADGES", 1);
+	MASTER("학습 마스터", "모든 업적을 달성했습니다", "master.png", "ALL_BADGES", 1),
+
+	// 뉴스 - 읽기
+	NEWS_FIRST_READ("뉴스 첫 발걸음", "첫 번째 뉴스 읽기 완료", "news_first_read.png", "NEWS_READ", 1),
+	NEWS_READ_10("뉴스 탐험가", "뉴스 10개 읽기 완료", "news_read_10.png", "NEWS_READ", 10),
+	NEWS_READ_50("뉴스 애호가", "뉴스 50개 읽기 완료", "news_read_50.png", "NEWS_READ", 50),
+	NEWS_READ_100("뉴스 전문가", "뉴스 100개 읽기 완료", "news_read_100.png", "NEWS_READ", 100),
+
+	// 뉴스 - 퀴즈
+	NEWS_QUIZ_FIRST("퀴즈 도전", "첫 뉴스 퀴즈 완료", "news_quiz_first.png", "NEWS_QUIZ", 1),
+	NEWS_QUIZ_PERFECT("완벽한 이해", "뉴스 퀴즈에서 만점 달성", "news_quiz_perfect.png", "NEWS_QUIZ_PERFECT", 1),
+	NEWS_QUIZ_10("퀴즈 탐험가", "뉴스 퀴즈 10회 완료", "news_quiz_10.png", "NEWS_QUIZ", 10),
+	NEWS_QUIZ_50("퀴즈 마스터", "뉴스 퀴즈 50회 완료", "news_quiz_50.png", "NEWS_QUIZ", 50),
+
+	// 뉴스 - 단어 수집
+	NEWS_WORD_10("단어 수집가", "뉴스에서 단어 10개 수집", "news_word_10.png", "NEWS_WORD", 10),
+	NEWS_WORD_50("단어 사냥꾼", "뉴스에서 단어 50개 수집", "news_word_50.png", "NEWS_WORD", 50),
+	NEWS_WORD_100("단어 전문가", "뉴스에서 단어 100개 수집", "news_word_100.png", "NEWS_WORD", 100),
+
+	// 뉴스 - 연속 학습
+	NEWS_STREAK_7("일주일 뉴스 습관", "7일 연속 뉴스 읽기", "news_streak_7.png", "NEWS_STREAK", 7),
+	NEWS_STREAK_30("한 달 뉴스 습관", "30일 연속 뉴스 읽기", "news_streak_30.png", "NEWS_STREAK", 30),
+
+	// 뉴스 - 종합
+	NEWS_MASTER("뉴스 마스터", "읽기100+퀴즈50+단어100 달성", "news_master.png", "NEWS_MASTER", 1);
 
 	private static final String BUCKET_NAME = System.getenv("BUCKET_NAME");
 	private static final String BASE_URL = getBaseUrl();

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/BadgeConditionStrategyFactory.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/BadgeConditionStrategyFactory.java
@@ -22,6 +22,13 @@ public class BadgeConditionStrategyFactory {
 		register(new GamesWonStrategy());
 		register(new QuickGuessesStrategy());
 		register(new PerfectDrawsStrategy());
+		// 뉴스 관련 전략
+		register(new NewsReadStrategy());
+		register(new NewsQuizStrategy());
+		register(new NewsQuizPerfectStrategy());
+		register(new NewsWordStrategy());
+		register(new NewsStreakStrategy());
+		register(new NewsMasterStrategy());
 		// 별도 로직이 필요한 카테고리
 		register(new NoOpStrategy("PERFECT_TEST"));
 		register(new NoOpStrategy("ALL_BADGES"));

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsMasterStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsMasterStrategy.java
@@ -1,0 +1,45 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 뉴스 마스터 뱃지 조건 전략
+ * 읽기 100개 + 퀴즈 50회 + 단어 100개 달성 시 획득
+ */
+public class NewsMasterStrategy implements BadgeConditionStrategy {
+
+	private static final int NEWS_READ_REQUIRED = 100;
+	private static final int NEWS_QUIZ_REQUIRED = 50;
+	private static final int NEWS_WORD_REQUIRED = 100;
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		int newsRead = stats.getNewsRead() != null ? stats.getNewsRead() : 0;
+		int newsQuiz = stats.getNewsQuizCompleted() != null ? stats.getNewsQuizCompleted() : 0;
+		int newsWord = stats.getNewsWordsCollected() != null ? stats.getNewsWordsCollected() : 0;
+
+		return newsRead >= NEWS_READ_REQUIRED
+				&& newsQuiz >= NEWS_QUIZ_REQUIRED
+				&& newsWord >= NEWS_WORD_REQUIRED;
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		int newsRead = stats.getNewsRead() != null ? stats.getNewsRead() : 0;
+		int newsQuiz = stats.getNewsQuizCompleted() != null ? stats.getNewsQuizCompleted() : 0;
+		int newsWord = stats.getNewsWordsCollected() != null ? stats.getNewsWordsCollected() : 0;
+
+		// 3가지 조건의 평균 진행률 (각각 100%, 100%, 100% 기준)
+		int readProgress = Math.min(newsRead * 100 / NEWS_READ_REQUIRED, 100);
+		int quizProgress = Math.min(newsQuiz * 100 / NEWS_QUIZ_REQUIRED, 100);
+		int wordProgress = Math.min(newsWord * 100 / NEWS_WORD_REQUIRED, 100);
+
+		return (readProgress + quizProgress + wordProgress) / 3;
+	}
+
+	@Override
+	public String getCategory() {
+		return "NEWS_MASTER";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsQuizPerfectStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsQuizPerfectStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 뉴스 퀴즈 만점 뱃지 조건 전략
+ */
+public class NewsQuizPerfectStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getNewsQuizPerfect() != null && stats.getNewsQuizPerfect() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getNewsQuizPerfect() != null ? stats.getNewsQuizPerfect() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "NEWS_QUIZ_PERFECT";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsQuizStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsQuizStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 뉴스 퀴즈 완료 뱃지 조건 전략
+ */
+public class NewsQuizStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getNewsQuizCompleted() != null && stats.getNewsQuizCompleted() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getNewsQuizCompleted() != null ? stats.getNewsQuizCompleted() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "NEWS_QUIZ";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsReadStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsReadStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 뉴스 읽기 뱃지 조건 전략
+ */
+public class NewsReadStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getNewsRead() != null && stats.getNewsRead() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getNewsRead() != null ? stats.getNewsRead() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "NEWS_READ";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsStreakStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsStreakStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 뉴스 연속 읽기 뱃지 조건 전략
+ */
+public class NewsStreakStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getNewsStreak() != null && stats.getNewsStreak() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getNewsStreak() != null ? stats.getNewsStreak() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "NEWS_STREAK";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsWordStrategy.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/strategy/NewsWordStrategy.java
@@ -1,0 +1,25 @@
+package com.mzc.secondproject.serverless.domain.badge.strategy;
+
+import com.mzc.secondproject.serverless.domain.badge.enums.BadgeType;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+
+/**
+ * 뉴스 단어 수집 뱃지 조건 전략
+ */
+public class NewsWordStrategy implements BadgeConditionStrategy {
+
+	@Override
+	public boolean checkCondition(BadgeType type, UserStats stats) {
+		return stats.getNewsWordsCollected() != null && stats.getNewsWordsCollected() >= type.getThreshold();
+	}
+
+	@Override
+	public int calculateProgress(BadgeType type, UserStats stats) {
+		return stats.getNewsWordsCollected() != null ? stats.getNewsWordsCollected() : 0;
+	}
+
+	@Override
+	public String getCategory() {
+		return "NEWS_WORD";
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/handler/NewsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/handler/NewsHandler.java
@@ -416,13 +416,19 @@ public class NewsHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 		String word = body.get("word").getAsString();
 		String context = body.has("context") ? body.get("context").getAsString() : "";
 
-		NewsWordCollect collected = wordService.collectWord(userId, articleId, word, context);
+		NewsWordService.WordCollectResult result = wordService.collectWord(userId, articleId, word, context);
 
-		if (collected == null) {
+		if (result == null || result.wordCollect() == null) {
 			return ResponseGenerator.fail(NewsErrorCode.WORD_ALREADY_COLLECTED);
 		}
 
-		return ResponseGenerator.ok("단어 수집 성공", collected);
+		Map<String, Object> responseData = new java.util.HashMap<>();
+		responseData.put("wordCollect", result.wordCollect());
+		if (result.newBadges() != null && !result.newBadges().isEmpty()) {
+			responseData.put("newBadges", result.newBadges());
+		}
+
+		return ResponseGenerator.ok("단어 수집 성공", responseData);
 	}
 
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsQuizService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsQuizService.java
@@ -1,9 +1,13 @@
 package com.mzc.secondproject.serverless.domain.news.service;
 
+import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
+import com.mzc.secondproject.serverless.domain.badge.service.BadgeService;
 import com.mzc.secondproject.serverless.domain.news.constants.NewsKey;
 import com.mzc.secondproject.serverless.domain.news.model.*;
 import com.mzc.secondproject.serverless.domain.news.repository.NewsArticleRepository;
 import com.mzc.secondproject.serverless.domain.news.repository.NewsQuizRepository;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,15 +24,22 @@ public class NewsQuizService {
 
 	private final NewsArticleRepository articleRepository;
 	private final NewsQuizRepository quizRepository;
+	private final UserStatsRepository userStatsRepository;
+	private final BadgeService badgeService;
 
 	public NewsQuizService() {
 		this.articleRepository = new NewsArticleRepository();
 		this.quizRepository = new NewsQuizRepository();
+		this.userStatsRepository = new UserStatsRepository();
+		this.badgeService = new BadgeService();
 	}
 
-	public NewsQuizService(NewsArticleRepository articleRepository, NewsQuizRepository quizRepository) {
+	public NewsQuizService(NewsArticleRepository articleRepository, NewsQuizRepository quizRepository,
+						   UserStatsRepository userStatsRepository, BadgeService badgeService) {
 		this.articleRepository = articleRepository;
 		this.quizRepository = quizRepository;
+		this.userStatsRepository = userStatsRepository;
+		this.badgeService = badgeService;
 	}
 
 	/**
@@ -158,12 +169,29 @@ public class NewsQuizService {
 		// 피드백 생성
 		String feedback = generateFeedback(score, answerResults);
 
+		// 통계 업데이트 및 배지 체크
+		List<UserBadge> newBadges = new ArrayList<>();
+		try {
+			boolean isPerfect = score == 100;
+			UserStats updatedStats = userStatsRepository.incrementNewsQuizStats(userId, isPerfect);
+			if (updatedStats != null) {
+				newBadges = badgeService.checkAndAwardBadges(userId, updatedStats);
+				if (!newBadges.isEmpty()) {
+					logger.info("새 배지 획득: userId={}, badges={}", userId,
+							newBadges.stream().map(UserBadge::getBadgeType).toList());
+				}
+			}
+		} catch (Exception e) {
+			logger.error("통계/배지 업데이트 실패: userId={}, error={}", userId, e.getMessage());
+		}
+
 		return QuizSubmitResult.builder()
 				.score(score)
 				.earnedPoints(earnedPoints)
 				.totalPoints(totalPoints)
 				.results(answerResults)
 				.feedback(feedback)
+				.newBadges(newBadges)
 				.build();
 	}
 
@@ -259,5 +287,6 @@ public class NewsQuizService {
 		private int totalPoints;
 		private List<QuizAnswerResult> results;
 		private String feedback;
+		private List<UserBadge> newBadges;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsWordService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsWordService.java
@@ -1,10 +1,14 @@
 package com.mzc.secondproject.serverless.domain.news.service;
 
+import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
+import com.mzc.secondproject.serverless.domain.badge.service.BadgeService;
 import com.mzc.secondproject.serverless.domain.news.constants.NewsKey;
 import com.mzc.secondproject.serverless.domain.news.model.NewsArticle;
 import com.mzc.secondproject.serverless.domain.news.model.NewsWordCollect;
 import com.mzc.secondproject.serverless.domain.news.repository.NewsArticleRepository;
 import com.mzc.secondproject.serverless.domain.news.repository.NewsWordRepository;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
 import com.mzc.secondproject.serverless.domain.vocabulary.model.Word;
 import com.mzc.secondproject.serverless.domain.vocabulary.repository.WordRepository;
 import com.mzc.secondproject.serverless.domain.vocabulary.service.UserWordCommandService;
@@ -12,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,32 +32,42 @@ public class NewsWordService {
 	private final NewsArticleRepository articleRepository;
 	private final WordRepository wordRepository;
 	private final UserWordCommandService userWordCommandService;
+	private final UserStatsRepository userStatsRepository;
+	private final BadgeService badgeService;
 
 	public NewsWordService() {
 		this.newsWordRepository = new NewsWordRepository();
 		this.articleRepository = new NewsArticleRepository();
 		this.wordRepository = new WordRepository();
 		this.userWordCommandService = new UserWordCommandService();
+		this.userStatsRepository = new UserStatsRepository();
+		this.badgeService = new BadgeService();
 	}
 
 	public NewsWordService(NewsWordRepository newsWordRepository,
 						   NewsArticleRepository articleRepository,
 						   WordRepository wordRepository,
-						   UserWordCommandService userWordCommandService) {
+						   UserWordCommandService userWordCommandService,
+						   UserStatsRepository userStatsRepository,
+						   BadgeService badgeService) {
 		this.newsWordRepository = newsWordRepository;
 		this.articleRepository = articleRepository;
 		this.wordRepository = wordRepository;
 		this.userWordCommandService = userWordCommandService;
+		this.userStatsRepository = userStatsRepository;
+		this.badgeService = badgeService;
 	}
 
 	/**
 	 * 단어 수집
+	 * @return 수집 결과 (단어 정보 + 새로 획득한 배지)
 	 */
-	public NewsWordCollect collectWord(String userId, String articleId, String word, String context) {
+	public WordCollectResult collectWord(String userId, String articleId, String word, String context) {
 		// 이미 수집했는지 확인
 		if (newsWordRepository.hasCollected(userId, word, articleId)) {
 			logger.warn("이미 수집한 단어: userId={}, word={}", userId, word);
-			return newsWordRepository.findByUserWordArticle(userId, word, articleId).orElse(null);
+			NewsWordCollect existing = newsWordRepository.findByUserWordArticle(userId, word, articleId).orElse(null);
+			return new WordCollectResult(existing, new ArrayList<>());
 		}
 
 		// 기사 조회
@@ -86,8 +101,28 @@ public class NewsWordService {
 		newsWordRepository.save(wordCollect);
 		logger.info("단어 수집 완료: userId={}, word={}, articleId={}", userId, word, articleId);
 
-		return wordCollect;
+		// 통계 업데이트 및 배지 체크
+		List<UserBadge> newBadges = new ArrayList<>();
+		try {
+			UserStats updatedStats = userStatsRepository.incrementNewsWordStats(userId, 1);
+			if (updatedStats != null) {
+				newBadges = badgeService.checkAndAwardBadges(userId, updatedStats);
+				if (!newBadges.isEmpty()) {
+					logger.info("새 배지 획득: userId={}, badges={}", userId,
+							newBadges.stream().map(UserBadge::getBadgeType).toList());
+				}
+			}
+		} catch (Exception e) {
+			logger.error("통계/배지 업데이트 실패: userId={}, error={}", userId, e.getMessage());
+		}
+
+		return new WordCollectResult(wordCollect, newBadges);
 	}
+
+	/**
+	 * 단어 수집 결과
+	 */
+	public record WordCollectResult(NewsWordCollect wordCollect, List<UserBadge> newBadges) {}
 
 	/**
 	 * 수집한 단어 삭제

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/model/UserStats.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/stats/model/UserStats.java
@@ -56,7 +56,15 @@ public class UserStats {
 	private Integer totalGameScore;     // 누적 게임 점수
 	private Integer quickGuesses;       // 5초 내 정답 횟수
 	private Integer perfectDraws;       // 전원 정답 유도 횟수
-	
+
+	// 뉴스 통계
+	private Integer newsRead;           // 읽은 뉴스 수
+	private Integer newsQuizCompleted;  // 완료한 뉴스 퀴즈 수
+	private Integer newsQuizPerfect;    // 뉴스 퀴즈 만점 횟수
+	private Integer newsWordsCollected; // 뉴스에서 수집한 단어 수
+	private Integer newsStreak;         // 뉴스 연속 읽기 일수
+	private String lastNewsReadDate;    // 마지막 뉴스 읽은 날짜
+
 	// 메타데이터
 	private String createdAt;
 	private String updatedAt;


### PR DESCRIPTION
## Summary
- 14개 뉴스 관련 배지 추가 (읽기, 퀴즈, 단어수집, 연속학습, 마스터)
- UserStats에 뉴스 통계 필드 추가
- 6개 뉴스 배지 Strategy 클래스 생성
- 뉴스 읽기/퀴즈/단어수집 시 통계 업데이트 및 배지 체크 연동

## Changes
### 새 파일
- `NewsReadStrategy.java` - 뉴스 읽기 배지 전략
- `NewsQuizStrategy.java` - 뉴스 퀴즈 배지 전략
- `NewsQuizPerfectStrategy.java` - 퀴즈 만점 배지 전략
- `NewsWordStrategy.java` - 단어 수집 배지 전략
- `NewsStreakStrategy.java` - 연속 읽기 배지 전략
- `NewsMasterStrategy.java` - 종합 마스터 배지 전략

### 수정 파일
- `BadgeType.java` - 14개 뉴스 배지 enum 추가
- `UserStats.java` - 뉴스 통계 필드 추가
- `BadgeConditionStrategyFactory.java` - 뉴스 전략 등록
- `UserStatsRepository.java` - 뉴스 통계 업데이트 메서드 추가
- `NewsLearningService.java` - 읽기 완료 시 배지 체크
- `NewsQuizService.java` - 퀴즈 완료 시 배지 체크
- `NewsWordService.java` - 단어 수집 시 배지 체크
- `NewsHandler.java` - 응답에 배지 포함

## Test plan
- [ ] 뉴스 읽기 후 통계 증가 확인
- [ ] 퀴즈 완료 후 통계/배지 확인
- [ ] 단어 수집 후 통계/배지 확인
- [ ] 배지 조건 충족 시 배지 획득 확인