### PR TITLE
feat: Epic #499 - Real-time Notification System

### DIFF
--- a/ServerlessFunction/build.gradle
+++ b/ServerlessFunction/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'software.amazon.awssdk:url-connection-client'
     implementation 'software.amazon.awssdk:ssm'
     implementation 'software.amazon.awssdk:scheduler'
+    implementation 'software.amazon.awssdk:sqs'
 
     // AWS X-Ray SDK (다운스트림 서비스 추적용)
     implementation 'com.amazonaws:aws-xray-recorder-sdk-core:2.15.0'

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/AwsClients.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/AwsClients.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.polly.PollyClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.ssm.SsmClient;
 
 /**
@@ -60,7 +61,12 @@ public final class AwsClients {
 	private static final SsmClient SSM_CLIENT = SsmClient.builder()
 			.overrideConfiguration(XRAY_CONFIG)
 			.build();
-	
+
+	// SQS
+	private static final SqsClient SQS_CLIENT = SqsClient.builder()
+			.overrideConfiguration(XRAY_CONFIG)
+			.build();
+
 	private AwsClients() {
 		// 인스턴스화 방지
 	}
@@ -103,5 +109,9 @@ public final class AwsClients {
 	
 	public static SsmClient ssm() {
 		return SSM_CLIENT;
+	}
+
+	public static SqsClient sqs() {
+		return SQS_CLIENT;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/EnvConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/config/EnvConfig.java
@@ -15,7 +15,18 @@ public final class EnvConfig {
 	private EnvConfig() {
 		// 유틸리티 클래스 - 인스턴스화 방지
 	}
-	
+
+	/**
+	 * 선택적 환경 변수를 가져옵니다.
+	 * 환경 변수가 설정되지 않은 경우 null을 반환합니다.
+	 *
+	 * @param name 환경 변수 이름
+	 * @return 환경 변수 값 또는 null
+	 */
+	public static String get(String name) {
+		return System.getenv(name);
+	}
+
 	/**
 	 * 필수 환경 변수를 가져옵니다.
 	 * 환경 변수가 설정되지 않았거나 빈 문자열인 경우 IllegalStateException을 발생시킵니다.

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/JsonUtil.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/common/util/JsonUtil.java
@@ -1,5 +1,7 @@
 package com.mzc.secondproject.serverless.common.util;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
@@ -10,8 +12,24 @@ import java.util.List;
  * JSON 파싱 관련 공통 유틸리티
  */
 public class JsonUtil {
-	
+
+	private static final Gson GSON = new GsonBuilder().create();
+
 	private JsonUtil() {
+	}
+
+	/**
+	 * 객체를 JSON 문자열로 변환
+	 */
+	public static String toJson(Object obj) {
+		return GSON.toJson(obj);
+	}
+
+	/**
+	 * JSON 문자열을 객체로 변환
+	 */
+	public static <T> T fromJson(String json, Class<T> clazz) {
+		return GSON.fromJson(json, clazz);
 	}
 	
 	// 응답에서 JSON 부분만 추출

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/service/BadgeService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/badge/service/BadgeService.java
@@ -7,6 +7,7 @@ import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
 import com.mzc.secondproject.serverless.domain.badge.repository.BadgeRepository;
 import com.mzc.secondproject.serverless.domain.badge.strategy.BadgeConditionStrategy;
 import com.mzc.secondproject.serverless.domain.badge.strategy.BadgeConditionStrategyFactory;
+import com.mzc.secondproject.serverless.domain.notification.service.NotificationPublisher;
 import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
 import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
 import org.slf4j.Logger;
@@ -24,20 +25,23 @@ public class BadgeService {
 	
 	private final BadgeRepository badgeRepository;
 	private final UserStatsRepository userStatsRepository;
-	
+	private final NotificationPublisher notificationPublisher;
+
 	/**
 	 * 기본 생성자 (Lambda에서 사용)
 	 */
 	public BadgeService() {
-		this(new BadgeRepository(), new UserStatsRepository());
+		this(new BadgeRepository(), new UserStatsRepository(), NotificationPublisher.getInstance());
 	}
-	
+
 	/**
 	 * 의존성 주입 생성자 (테스트 용이성)
 	 */
-	public BadgeService(BadgeRepository badgeRepository, UserStatsRepository userStatsRepository) {
+	public BadgeService(BadgeRepository badgeRepository, UserStatsRepository userStatsRepository,
+						NotificationPublisher notificationPublisher) {
 		this.badgeRepository = badgeRepository;
 		this.userStatsRepository = userStatsRepository;
+		this.notificationPublisher = notificationPublisher;
 	}
 	
 	/**
@@ -98,6 +102,15 @@ public class BadgeService {
 				badgeRepository.save(badge);
 				newBadges.add(badge);
 				logger.info("Badge awarded: userId={}, badge={}", userId, type.name());
+
+				// 알림 발행
+				notificationPublisher.publishBadgeEarned(
+						userId,
+						type.name(),
+						type.getName(),
+						type.getDescription(),
+						badge.getImageUrl()
+				);
 			}
 		}
 		

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/config/NewsConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/config/NewsConfig.java
@@ -1,0 +1,83 @@
+package com.mzc.secondproject.serverless.domain.news.config;
+
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+
+/**
+ * 뉴스 도메인 설정
+ * 상수 및 환경변수 관리
+ */
+public final class NewsConfig {
+
+	private NewsConfig() {
+	}
+
+	// ========== Environment Variables ==========
+	private static final String BUCKET_NAME = EnvConfig.getOrDefault("NEWS_BUCKET_NAME", "group2-englishstudy");
+
+	// ========== TTS 설정 ==========
+	/** TTS 텍스트 최대 길이 */
+	public static final int TTS_MAX_TEXT_LENGTH = 3000;
+
+	/** TTS 오디오 저장 경로 */
+	public static final String TTS_AUDIO_PREFIX = "news/audio/";
+
+	/** 기본 TTS 음성 */
+	public static final String DEFAULT_VOICE = "Joanna";
+
+	// ========== 페이지네이션 ==========
+	/** 기본 페이지 크기 */
+	public static final int DEFAULT_PAGE_SIZE = 10;
+
+	/** 최대 페이지 크기 */
+	public static final int MAX_PAGE_SIZE = 50;
+
+	// ========== 퀴즈 피드백 ==========
+	public static final String FEEDBACK_PERFECT = "Perfect! You understood the article completely.";
+	public static final String FEEDBACK_GREAT = "Great job! You have a solid understanding of the article.";
+	public static final String FEEDBACK_GOOD = "Good effort! Review the highlighted words for better comprehension.";
+	public static final String FEEDBACK_KEEP_PRACTICING = "Keep practicing! Try reading the article again before retaking the quiz.";
+	public static final String FEEDBACK_DONT_GIVE_UP = "Don't give up! Focus on vocabulary and main ideas.";
+
+	// ========== Score 기준 ==========
+	public static final int SCORE_PERFECT = 100;
+	public static final int SCORE_GREAT_THRESHOLD = 80;
+	public static final int SCORE_GOOD_THRESHOLD = 60;
+	public static final int SCORE_KEEP_PRACTICING_THRESHOLD = 40;
+
+	// ========== Getter Methods ==========
+	public static String bucketName() {
+		return BUCKET_NAME;
+	}
+
+	/**
+	 * 점수에 따른 피드백 생성
+	 */
+	public static String getFeedbackByScore(int score) {
+		if (score == SCORE_PERFECT) {
+			return FEEDBACK_PERFECT;
+		} else if (score >= SCORE_GREAT_THRESHOLD) {
+			return FEEDBACK_GREAT;
+		} else if (score >= SCORE_GOOD_THRESHOLD) {
+			return FEEDBACK_GOOD;
+		} else if (score >= SCORE_KEEP_PRACTICING_THRESHOLD) {
+			return FEEDBACK_KEEP_PRACTICING;
+		} else {
+			return FEEDBACK_DONT_GIVE_UP;
+		}
+	}
+
+	/**
+	 * limit 값 파싱 및 유효성 검증
+	 */
+	public static int parseLimit(String limitStr) {
+		if (limitStr == null) {
+			return DEFAULT_PAGE_SIZE;
+		}
+		try {
+			int limit = Integer.parseInt(limitStr);
+			return Math.min(Math.max(limit, 1), MAX_PAGE_SIZE);
+		} catch (NumberFormatException e) {
+			return DEFAULT_PAGE_SIZE;
+		}
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/constants/NewsKey.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/constants/NewsKey.java
@@ -126,4 +126,16 @@ public final class NewsKey {
 	public static String userNewsStatPk(String userId) {
 		return "USER_NEWS_STAT#" + userId;
 	}
+
+	// === Utility Methods ===
+
+	/**
+	 * PK에서 날짜 추출 (NEWS#2024-01-15 → 2024-01-15)
+	 */
+	public static String extractDateFromPk(String pk) {
+		if (pk == null || !pk.startsWith(NEWS)) {
+			return null;
+		}
+		return pk.substring(NEWS.length());
+	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/handler/NewsHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/handler/NewsHandler.java
@@ -4,14 +4,15 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.router.HandlerRouter;
 import com.mzc.secondproject.serverless.common.router.Route;
 import com.mzc.secondproject.serverless.common.util.CognitoUtil;
+import com.mzc.secondproject.serverless.common.util.JsonUtil;
 import com.mzc.secondproject.serverless.common.util.ResponseGenerator;
+import com.mzc.secondproject.serverless.domain.news.config.NewsConfig;
 import com.mzc.secondproject.serverless.domain.news.exception.NewsErrorCode;
 import com.mzc.secondproject.serverless.domain.news.model.NewsArticle;
 import com.mzc.secondproject.serverless.domain.news.model.NewsQuizResult;
@@ -32,12 +33,9 @@ import java.util.Optional;
  * 뉴스 학습 API 핸들러
  */
 public class NewsHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(NewsHandler.class);
-	private static final int DEFAULT_LIMIT = 10;
-	private static final int MAX_LIMIT = 50;
-	private static final Gson gson = new Gson();
-	
+
 	private final NewsQueryService queryService;
 	private final NewsLearningService learningService;
 	private final NewsQuizService quizService;
@@ -226,13 +224,7 @@ public class NewsHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 	 * limit 파싱
 	 */
 	private int parseLimit(String limitStr) {
-		if (limitStr == null) return DEFAULT_LIMIT;
-		try {
-			int limit = Integer.parseInt(limitStr);
-			return Math.min(Math.max(limit, 1), MAX_LIMIT);
-		} catch (NumberFormatException e) {
-			return DEFAULT_LIMIT;
-		}
+		return NewsConfig.parseLimit(limitStr);
 	}
 	
 	/**
@@ -374,7 +366,7 @@ public class NewsHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 		String articleId = request.getPathParameters().get("articleId");
 		
 		// 요청 바디 파싱
-		JsonObject body = gson.fromJson(request.getBody(), JsonObject.class);
+		JsonObject body = JsonUtil.fromJson(request.getBody(), JsonObject.class);
 		JsonArray answersArray = body.getAsJsonArray("answers");
 		Integer timeTaken = body.has("timeTaken") ? body.get("timeTaken").getAsInt() : null;
 		
@@ -460,7 +452,7 @@ public class NewsHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 		
 		String articleId = request.getPathParameters().get("articleId");
 		
-		JsonObject body = gson.fromJson(request.getBody(), JsonObject.class);
+		JsonObject body = JsonUtil.fromJson(request.getBody(), JsonObject.class);
 		String word = body.get("word").getAsString();
 		String context = body.has("context") ? body.get("context").getAsString() : "";
 		
@@ -519,7 +511,7 @@ public class NewsHandler implements RequestHandler<APIGatewayProxyRequestEvent, 
 		
 		String word = request.getPathParameters().get("word");
 		
-		JsonObject body = gson.fromJson(request.getBody(), JsonObject.class);
+		JsonObject body = JsonUtil.fromJson(request.getBody(), JsonObject.class);
 		String articleId = body.get("articleId").getAsString();
 		
 		boolean synced = wordService.syncToVocabulary(userId, word, articleId);

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsLearningService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsLearningService.java
@@ -1,9 +1,10 @@
 package com.mzc.secondproject.serverless.domain.news.service;
 
-import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.service.PollyService;
 import com.mzc.secondproject.serverless.domain.badge.model.UserBadge;
 import com.mzc.secondproject.serverless.domain.badge.service.BadgeService;
+import com.mzc.secondproject.serverless.domain.news.config.NewsConfig;
+import com.mzc.secondproject.serverless.domain.news.constants.NewsKey;
 import com.mzc.secondproject.serverless.domain.news.model.NewsArticle;
 import com.mzc.secondproject.serverless.domain.news.model.UserNewsRecord;
 import com.mzc.secondproject.serverless.domain.news.repository.NewsArticleRepository;
@@ -19,197 +20,141 @@ import java.util.*;
  * 뉴스 학습 부가 기능 서비스
  */
 public class NewsLearningService {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(NewsLearningService.class);
-	private static final String BUCKET_NAME = EnvConfig.getOrDefault("NEWS_BUCKET_NAME", "group2-englishstudy");
-	
+
 	private final NewsArticleRepository articleRepository;
 	private final UserNewsRepository userNewsRepository;
 	private final PollyService pollyService;
 	private final UserStatsRepository userStatsRepository;
 	private final BadgeService badgeService;
-	
+
 	public NewsLearningService() {
 		this.articleRepository = new NewsArticleRepository();
 		this.userNewsRepository = new UserNewsRepository();
-		this.pollyService = new PollyService(BUCKET_NAME, "news/audio/");
+		this.pollyService = new PollyService(NewsConfig.bucketName(), NewsConfig.TTS_AUDIO_PREFIX);
 		this.userStatsRepository = new UserStatsRepository();
 		this.badgeService = new BadgeService();
 	}
-	
+
 	public NewsLearningService(NewsArticleRepository articleRepository,
-	                           UserNewsRepository userNewsRepository,
-	                           PollyService pollyService,
-	                           UserStatsRepository userStatsRepository,
-	                           BadgeService badgeService) {
+							   UserNewsRepository userNewsRepository,
+							   PollyService pollyService,
+							   UserStatsRepository userStatsRepository,
+							   BadgeService badgeService) {
 		this.articleRepository = articleRepository;
 		this.userNewsRepository = userNewsRepository;
 		this.pollyService = pollyService;
 		this.userStatsRepository = userStatsRepository;
 		this.badgeService = badgeService;
 	}
-	
+
 	/**
 	 * 뉴스 읽기 완료 기록
 	 *
 	 * @return 새로 획득한 배지 목록
 	 */
 	public List<UserBadge> markAsRead(String userId, String articleId) {
-		Optional<NewsArticle> article = articleRepository.findById(articleId);
-		if (article.isEmpty()) {
+		Optional<NewsArticle> articleOpt = articleRepository.findById(articleId);
+		if (articleOpt.isEmpty()) {
 			logger.warn("기사를 찾을 수 없음: {}", articleId);
-			return new ArrayList<>();
+			return List.of();
 		}
-		
-		// 이미 읽은 기사인지 확인 (중복 조회수 증가 방지)
+
 		if (userNewsRepository.hasRead(userId, articleId)) {
 			logger.debug("이미 읽은 기사: userId={}, articleId={}", userId, articleId);
-			return new ArrayList<>();
+			return List.of();
 		}
-		
-		NewsArticle a = article.get();
-		userNewsRepository.saveReadRecord(
-				userId,
-				articleId,
-				a.getTitle(),
-				a.getLevel(),
-				a.getCategory()
-		);
-		
-		// 조회수 증가 (새로운 읽기만)
-		String date = extractDateFromPk(a.getPk());
-		if (date != null) {
-			articleRepository.incrementReadCount(date, articleId);
-		}
-		
+
+		NewsArticle article = articleOpt.get();
+		saveReadRecord(userId, article);
+		incrementArticleReadCount(article);
+
 		logger.info("읽기 완료 기록: userId={}, articleId={}", userId, articleId);
-		
-		// 통계 업데이트 및 배지 체크
-		List<UserBadge> newBadges = new ArrayList<>();
-		try {
-			UserStats updatedStats = userStatsRepository.incrementNewsReadStats(userId);
-			if (updatedStats != null) {
-				newBadges = badgeService.checkAndAwardBadges(userId, updatedStats);
-				if (!newBadges.isEmpty()) {
-					logger.info("새 배지 획득: userId={}, badges={}", userId,
-							newBadges.stream().map(UserBadge::getBadgeType).toList());
-				}
-			}
-		} catch (Exception e) {
-			logger.error("통계/배지 업데이트 실패: userId={}, error={}", userId, e.getMessage());
-		}
-		
-		return newBadges;
+
+		return updateStatsAndCheckBadges(userId);
 	}
-	
+
 	/**
 	 * 북마크 토글
 	 */
 	public boolean toggleBookmark(String userId, String articleId) {
-		boolean isBookmarked = userNewsRepository.isBookmarked(userId, articleId);
-		
-		if (isBookmarked) {
+		if (userNewsRepository.isBookmarked(userId, articleId)) {
 			userNewsRepository.deleteBookmark(userId, articleId);
 			logger.info("북마크 해제: userId={}, articleId={}", userId, articleId);
 			return false;
-		} else {
-			Optional<NewsArticle> article = articleRepository.findById(articleId);
-			if (article.isEmpty()) {
-				logger.warn("기사를 찾을 수 없음: {}", articleId);
-				return false;
-			}
-			
-			NewsArticle a = article.get();
-			userNewsRepository.saveBookmark(
-					userId,
-					articleId,
-					a.getTitle(),
-					a.getLevel(),
-					a.getCategory()
-			);
-			logger.info("북마크 추가: userId={}, articleId={}", userId, articleId);
-			return true;
 		}
+
+		Optional<NewsArticle> articleOpt = articleRepository.findById(articleId);
+		if (articleOpt.isEmpty()) {
+			logger.warn("기사를 찾을 수 없음: {}", articleId);
+			return false;
+		}
+
+		NewsArticle article = articleOpt.get();
+		userNewsRepository.saveBookmark(userId, articleId, article.getTitle(), article.getLevel(), article.getCategory());
+		logger.info("북마크 추가: userId={}, articleId={}", userId, articleId);
+		return true;
 	}
-	
+
 	/**
 	 * 북마크 여부 확인
 	 */
 	public boolean isBookmarked(String userId, String articleId) {
 		return userNewsRepository.isBookmarked(userId, articleId);
 	}
-	
+
 	/**
 	 * 읽기 여부 확인
 	 */
 	public boolean hasRead(String userId, String articleId) {
 		return userNewsRepository.hasRead(userId, articleId);
 	}
-	
+
 	/**
 	 * 여러 기사의 북마크 여부 확인 (배치)
 	 */
 	public Set<String> getBookmarkedArticleIds(String userId, List<String> articleIds) {
 		return userNewsRepository.getBookmarkedArticleIds(userId, articleIds);
 	}
-	
+
 	/**
 	 * 사용자 북마크 목록 조회 (기사 정보 포함)
 	 */
 	public List<Map<String, Object>> getUserBookmarks(String userId, int limit) {
 		List<UserNewsRecord> bookmarks = userNewsRepository.getUserBookmarks(userId, limit);
-		List<Map<String, Object>> result = new ArrayList<>();
-		
-		for (UserNewsRecord bookmark : bookmarks) {
-			Optional<NewsArticle> articleOpt = articleRepository.findById(bookmark.getArticleId());
-			if (articleOpt.isPresent()) {
-				NewsArticle article = articleOpt.get();
-				Map<String, Object> bookmarkWithArticle = new HashMap<>();
-				bookmarkWithArticle.put("articleId", article.getArticleId());
-				bookmarkWithArticle.put("title", article.getTitle());
-				bookmarkWithArticle.put("summary", article.getSummary());
-				bookmarkWithArticle.put("source", article.getSource());
-				bookmarkWithArticle.put("publishedAt", article.getPublishedAt());
-				bookmarkWithArticle.put("keywords", article.getKeywords());
-				bookmarkWithArticle.put("highlightWords", article.getHighlightWords());
-				bookmarkWithArticle.put("category", article.getCategory());
-				bookmarkWithArticle.put("level", article.getLevel());
-				bookmarkWithArticle.put("imageUrl", article.getImageUrl());
-				bookmarkWithArticle.put("bookmarkedAt", bookmark.getCreatedAt());
-				result.add(bookmarkWithArticle);
-			}
-		}
-		return result;
+
+		return bookmarks.stream()
+				.map(bookmark -> articleRepository.findById(bookmark.getArticleId())
+						.map(article -> buildBookmarkResponse(article, bookmark))
+						.orElse(null))
+				.filter(Objects::nonNull)
+				.toList();
 	}
-	
+
 	/**
 	 * 뉴스 TTS 오디오 URL 생성
 	 */
 	public String getAudioUrl(String articleId, String voice) {
-		Optional<NewsArticle> article = articleRepository.findById(articleId);
-		if (article.isEmpty()) {
+		Optional<NewsArticle> articleOpt = articleRepository.findById(articleId);
+		if (articleOpt.isEmpty()) {
 			logger.warn("기사를 찾을 수 없음: {}", articleId);
 			return null;
 		}
-		
-		NewsArticle a = article.get();
-		String text = a.getTitle() + ". " + (a.getSummary() != null ? a.getSummary() : "");
-		
-		// 텍스트가 너무 길면 제한
-		if (text.length() > 3000) {
-			text = text.substring(0, 3000);
-		}
-		
+
+		NewsArticle article = articleOpt.get();
+		String text = buildTtsText(article);
+
 		PollyService.VoiceSynthesisResult result = pollyService.synthesizeSpeech(articleId, text, voice);
 		return result.getAudioUrl();
 	}
-	
+
 	/**
 	 * 사용자 뉴스 학습 통계 조회
 	 */
 	public Map<String, Object> getUserStats(String userId) {
 		UserNewsRepository.NewsStats stats = userNewsRepository.getUserStats(userId);
-		
+
 		return Map.of(
 				"totalRead", stats.totalRead(),
 				"thisWeekRead", stats.thisWeekRead(),
@@ -218,14 +163,64 @@ public class NewsLearningService {
 				"byCategory", stats.byCategory()
 		);
 	}
-	
-	/**
-	 * PK에서 날짜 추출
-	 */
-	private String extractDateFromPk(String pk) {
-		if (pk == null || !pk.startsWith("NEWS#")) {
-			return null;
+
+	// ========== Private Helper Methods ==========
+
+	private void saveReadRecord(String userId, NewsArticle article) {
+		userNewsRepository.saveReadRecord(
+				userId,
+				article.getArticleId(),
+				article.getTitle(),
+				article.getLevel(),
+				article.getCategory()
+		);
+	}
+
+	private void incrementArticleReadCount(NewsArticle article) {
+		String date = NewsKey.extractDateFromPk(article.getPk());
+		if (date != null) {
+			articleRepository.incrementReadCount(date, article.getArticleId());
 		}
-		return pk.substring(5);
+	}
+
+	private List<UserBadge> updateStatsAndCheckBadges(String userId) {
+		try {
+			UserStats updatedStats = userStatsRepository.incrementNewsReadStats(userId);
+			if (updatedStats != null) {
+				List<UserBadge> newBadges = badgeService.checkAndAwardBadges(userId, updatedStats);
+				if (!newBadges.isEmpty()) {
+					logger.info("새 배지 획득: userId={}, badges={}",
+							userId, newBadges.stream().map(UserBadge::getBadgeType).toList());
+				}
+				return newBadges;
+			}
+		} catch (Exception e) {
+			logger.error("통계/배지 업데이트 실패: userId={}, error={}", userId, e.getMessage());
+		}
+		return List.of();
+	}
+
+	private Map<String, Object> buildBookmarkResponse(NewsArticle article, UserNewsRecord bookmark) {
+		Map<String, Object> response = new HashMap<>();
+		response.put("articleId", article.getArticleId());
+		response.put("title", article.getTitle());
+		response.put("summary", article.getSummary());
+		response.put("source", article.getSource());
+		response.put("publishedAt", article.getPublishedAt());
+		response.put("keywords", article.getKeywords());
+		response.put("highlightWords", article.getHighlightWords());
+		response.put("category", article.getCategory());
+		response.put("level", article.getLevel());
+		response.put("imageUrl", article.getImageUrl());
+		response.put("bookmarkedAt", bookmark.getCreatedAt());
+		return response;
+	}
+
+	private String buildTtsText(NewsArticle article) {
+		String text = article.getTitle() + ". " + (article.getSummary() != null ? article.getSummary() : "");
+		if (text.length() > NewsConfig.TTS_MAX_TEXT_LENGTH) {
+			text = text.substring(0, NewsConfig.TTS_MAX_TEXT_LENGTH);
+		}
+		return text;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsQueryService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsQueryService.java
@@ -1,6 +1,7 @@
 package com.mzc.secondproject.serverless.domain.news.service;
 
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
+import com.mzc.secondproject.serverless.domain.news.constants.NewsKey;
 import com.mzc.secondproject.serverless.domain.news.model.NewsArticle;
 import com.mzc.secondproject.serverless.domain.news.repository.NewsArticleRepository;
 import org.slf4j.Logger;
@@ -13,37 +14,31 @@ import java.util.Optional;
  * 뉴스 조회 서비스
  */
 public class NewsQueryService {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(NewsQueryService.class);
-	
+
 	private final NewsArticleRepository articleRepository;
-	
+
 	public NewsQueryService() {
 		this.articleRepository = new NewsArticleRepository();
 	}
-	
+
 	public NewsQueryService(NewsArticleRepository articleRepository) {
 		this.articleRepository = articleRepository;
 	}
-	
+
 	/**
 	 * 뉴스 상세 조회
 	 */
 	public Optional<NewsArticle> getArticle(String articleId) {
 		logger.debug("뉴스 상세 조회: {}", articleId);
 		Optional<NewsArticle> article = articleRepository.findById(articleId);
-		
-		// 조회수 증가
-		article.ifPresent(a -> {
-			String date = extractDateFromPk(a.getPk());
-			if (date != null) {
-				articleRepository.incrementReadCount(date, articleId);
-			}
-		});
-		
+
+		article.ifPresent(this::incrementReadCount);
+
 		return article;
 	}
-	
+
 	/**
 	 * 오늘의 뉴스 목록 조회
 	 */
@@ -52,7 +47,7 @@ public class NewsQueryService {
 		logger.debug("오늘의 뉴스 조회: date={}, limit={}", today, limit);
 		return articleRepository.findByDate(today, limit, cursor);
 	}
-	
+
 	/**
 	 * 레벨별 뉴스 조회
 	 */
@@ -60,7 +55,7 @@ public class NewsQueryService {
 		logger.debug("레벨별 뉴스 조회: level={}, limit={}", level, limit);
 		return articleRepository.findByLevel(level, limit, cursor);
 	}
-	
+
 	/**
 	 * 카테고리별 뉴스 조회
 	 */
@@ -68,7 +63,7 @@ public class NewsQueryService {
 		logger.debug("카테고리별 뉴스 조회: category={}, limit={}", category, limit);
 		return articleRepository.findByCategory(category, limit, cursor);
 	}
-	
+
 	/**
 	 * 레벨 + 카테고리 복합 필터 조회
 	 */
@@ -76,23 +71,19 @@ public class NewsQueryService {
 		logger.debug("레벨+카테고리 뉴스 조회: level={}, category={}, limit={}", level, category, limit);
 		return articleRepository.findByLevelAndCategory(level, category, limit, cursor);
 	}
-	
+
 	/**
 	 * 사용자 레벨 맞춤 뉴스 추천
 	 */
 	public PaginatedResult<NewsArticle> getRecommendedNews(String userLevel, int limit, String cursor) {
 		logger.debug("맞춤 뉴스 추천: userLevel={}, limit={}", userLevel, limit);
-		// 사용자 레벨에 맞는 뉴스 조회
 		return articleRepository.findByLevel(userLevel, limit, cursor);
 	}
-	
-	/**
-	 * PK에서 날짜 추출 (NEWS#2024-01-15 → 2024-01-15)
-	 */
-	private String extractDateFromPk(String pk) {
-		if (pk == null || !pk.startsWith("NEWS#")) {
-			return null;
+
+	private void incrementReadCount(NewsArticle article) {
+		String date = NewsKey.extractDateFromPk(article.getPk());
+		if (date != null) {
+			articleRepository.incrementReadCount(date, article.getArticleId());
 		}
-		return pk.substring(5);
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsQuizService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/news/service/NewsQuizService.java
@@ -1,5 +1,6 @@
 package com.mzc.secondproject.serverless.domain.news.service;
 
+import com.mzc.secondproject.serverless.domain.news.config.NewsConfig;
 import com.mzc.secondproject.serverless.domain.news.constants.NewsKey;
 import com.mzc.secondproject.serverless.domain.news.model.NewsArticle;
 import com.mzc.secondproject.serverless.domain.news.model.NewsQuizResult;
@@ -177,7 +178,7 @@ public class NewsQuizService {
 		);
 
 		// 피드백 생성
-		String feedback = generateFeedback(score, answerResults);
+		String feedback = generateFeedback(score);
 
 		return QuizSubmitResult.builder()
 				.score(score)
@@ -217,18 +218,8 @@ public class NewsQuizService {
 	/**
 	 * 피드백 생성
 	 */
-	private String generateFeedback(int score, List<QuizAnswerResult> results) {
-		if (score == 100) {
-			return "Perfect! You understood the article completely.";
-		} else if (score >= 80) {
-			return "Great job! You have a solid understanding of the article.";
-		} else if (score >= 60) {
-			return "Good effort! Review the highlighted words for better comprehension.";
-		} else if (score >= 40) {
-			return "Keep practicing! Try reading the article again before retaking the quiz.";
-		} else {
-			return "Don't give up! Focus on vocabulary and main ideas.";
-		}
+	private String generateFeedback(int score) {
+		return NewsConfig.getFeedbackByScore(score);
 	}
 	
 	/**

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/config/NotificationConfig.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/config/NotificationConfig.java
@@ -1,0 +1,51 @@
+package com.mzc.secondproject.serverless.domain.notification.config;
+
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+
+/**
+ * 알림 시스템 설정
+ * SSE 스트리밍, 폴링 등 알림 관련 상수 정의
+ */
+public final class NotificationConfig {
+
+	private NotificationConfig() {
+	}
+
+	// ========== Environment Variables ==========
+	private static final String TOPIC_ARN = EnvConfig.get("NOTIFICATION_TOPIC_ARN");
+	private static final String QUEUE_URL = EnvConfig.get("NOTIFICATION_QUEUE_URL");
+
+	// ========== SSE Streaming ==========
+	/** SSE 폴링 간격 (밀리초) */
+	public static final int SSE_POLL_INTERVAL_MS = 1000;
+
+	/** SSE 최대 스트림 지속 시간 (밀리초) - Lambda 15분 제한 고려 */
+	public static final int SSE_MAX_DURATION_MS = 840_000; // 14분
+
+	/** SSE 최대 메시지 수신 개수 */
+	public static final int SSE_MAX_MESSAGES_PER_POLL = 10;
+
+	/** SSE 롱 폴링 대기 시간 (초) */
+	public static final int SSE_WAIT_TIME_SECONDS = 1;
+
+	// ========== SSE Event Types ==========
+	public static final String EVENT_HEARTBEAT = "HEARTBEAT";
+	public static final String EVENT_STREAM_END = "STREAM_END";
+
+	// ========== Getter Methods ==========
+	public static String topicArn() {
+		return TOPIC_ARN;
+	}
+
+	public static String queueUrl() {
+		return QUEUE_URL;
+	}
+
+	public static boolean isTopicConfigured() {
+		return TOPIC_ARN != null && !TOPIC_ARN.isBlank();
+	}
+
+	public static boolean isQueueConfigured() {
+		return QUEUE_URL != null && !QUEUE_URL.isBlank();
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/dto/NotificationMessage.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/dto/NotificationMessage.java
@@ -1,0 +1,60 @@
+package com.mzc.secondproject.serverless.domain.notification.dto;
+
+import com.mzc.secondproject.serverless.domain.notification.enums.NotificationType;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * 알림 메시지 DTO
+ * SNS로 발행되고 SSE로 클라이언트에 전달되는 메시지 구조
+ */
+public record NotificationMessage(
+		String notificationId,
+		NotificationType type,
+		String userId,
+		Map<String, Object> payload,
+		String createdAt
+) {
+	/**
+	 * Builder 패턴으로 알림 메시지 생성
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+		private NotificationType type;
+		private String userId;
+		private Map<String, Object> payload;
+
+		public Builder type(NotificationType type) {
+			this.type = type;
+			return this;
+		}
+
+		public Builder userId(String userId) {
+			this.userId = userId;
+			return this;
+		}
+
+		public Builder payload(Map<String, Object> payload) {
+			this.payload = payload;
+			return this;
+		}
+
+		public NotificationMessage build() {
+			return new NotificationMessage(
+					generateNotificationId(),
+					type,
+					userId,
+					payload,
+					Instant.now().toString()
+			);
+		}
+
+		private String generateNotificationId() {
+			return "notif-" + java.util.UUID.randomUUID().toString().substring(0, 8);
+		}
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/enums/NotificationType.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/enums/NotificationType.java
@@ -1,0 +1,41 @@
+package com.mzc.secondproject.serverless.domain.notification.enums;
+
+/**
+ * 알림 타입 정의
+ * 새로운 알림 타입 추가 시 여기에 enum 추가
+ */
+public enum NotificationType {
+	// 배지 관련
+	BADGE_EARNED("배지 획득", "badge"),
+
+	// 학습 관련
+	DAILY_COMPLETE("일일 학습 완료", "daily"),
+	STREAK_REMINDER("연속 학습 리마인더", "streak"),
+
+	// 테스트/퀴즈 관련
+	TEST_COMPLETE("테스트 완료", "test"),
+	NEWS_QUIZ_COMPLETE("뉴스 퀴즈 완료", "quiz"),
+
+	// 게임 관련
+	GAME_END("게임 종료", "game"),
+	GAME_STREAK("게임 연속 정답", "game"),
+
+	// OPIc 관련
+	OPIC_COMPLETE("OPIc 세션 완료", "opic");
+
+	private final String description;
+	private final String category;
+
+	NotificationType(String description, String category) {
+		this.description = description;
+		this.category = category;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public String getCategory() {
+		return category;
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/handler/NotificationStreamHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/handler/NotificationStreamHandler.java
@@ -1,0 +1,187 @@
+package com.mzc.secondproject.serverless.domain.notification.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+import com.mzc.secondproject.serverless.common.util.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * SSE(Server-Sent Events) 알림 스트리밍 Lambda Handler
+ * Lambda Function URL with Response Streaming을 사용하여 실시간 알림 제공
+ *
+ * 클라이언트 연결 예시:
+ * const eventSource = new EventSource('https://{function-url}/?userId={userId}');
+ * eventSource.onmessage = (event) => console.log(JSON.parse(event.data));
+ */
+public class NotificationStreamHandler implements RequestStreamHandler {
+
+	private static final Logger logger = LoggerFactory.getLogger(NotificationStreamHandler.class);
+	private static final String QUEUE_URL = EnvConfig.get("NOTIFICATION_QUEUE_URL");
+	private static final int POLL_INTERVAL_MS = 1000;
+	private static final int MAX_STREAM_DURATION_MS = 840000; // 14분 (Lambda 15분 제한 고려)
+
+	private final SqsClient sqsClient;
+
+	public NotificationStreamHandler() {
+		this.sqsClient = AwsClients.sqs();
+	}
+
+	public NotificationStreamHandler(SqsClient sqsClient) {
+		this.sqsClient = sqsClient;
+	}
+
+	@Override
+	public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+		Map<String, Object> event = parseEvent(input);
+		String userId = extractUserId(event);
+
+		if (userId == null || userId.isBlank()) {
+			sendErrorResponse(output, 400, "userId query parameter is required");
+			return;
+		}
+
+		logger.info("SSE connection started for userId: {}", userId);
+
+		try (BufferedOutputStream bufferedOutput = new BufferedOutputStream(output)) {
+			writeSSEHeaders(bufferedOutput);
+			sendHeartbeat(bufferedOutput);
+
+			long startTime = System.currentTimeMillis();
+
+			while (!isTimeoutReached(startTime)) {
+				List<Message> messages = pollMessages(userId);
+
+				for (Message message : messages) {
+					if (isMessageForUser(message, userId)) {
+						sendSSEEvent(bufferedOutput, message.body());
+						deleteMessage(message);
+					}
+				}
+
+				if (messages.isEmpty()) {
+					sendHeartbeat(bufferedOutput);
+				}
+
+				sleep(POLL_INTERVAL_MS);
+			}
+
+			sendSSEEvent(bufferedOutput, "{\"type\":\"STREAM_END\",\"message\":\"Connection timeout\"}");
+			logger.info("SSE connection ended for userId: {} (timeout)", userId);
+
+		} catch (Exception e) {
+			logger.error("SSE stream error for userId: {}", userId, e);
+		}
+	}
+
+	private Map<String, Object> parseEvent(InputStream input) throws IOException {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+			StringBuilder sb = new StringBuilder();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				sb.append(line);
+			}
+			return JsonUtil.fromJson(sb.toString(), Map.class);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private String extractUserId(Map<String, Object> event) {
+		Object queryParams = event.get("queryStringParameters");
+		if (queryParams instanceof Map) {
+			Object userId = ((Map<String, Object>) queryParams).get("userId");
+			return userId != null ? userId.toString() : null;
+		}
+		return null;
+	}
+
+	private void writeSSEHeaders(OutputStream output) throws IOException {
+		String headers = "HTTP/1.1 200 OK\r\n" +
+				"Content-Type: text/event-stream\r\n" +
+				"Cache-Control: no-cache\r\n" +
+				"Connection: keep-alive\r\n" +
+				"Access-Control-Allow-Origin: *\r\n" +
+				"\r\n";
+		output.write(headers.getBytes(StandardCharsets.UTF_8));
+		output.flush();
+	}
+
+	private void sendSSEEvent(OutputStream output, String data) throws IOException {
+		String event = "data: " + data + "\n\n";
+		output.write(event.getBytes(StandardCharsets.UTF_8));
+		output.flush();
+	}
+
+	private void sendHeartbeat(OutputStream output) throws IOException {
+		sendSSEEvent(output, "{\"type\":\"HEARTBEAT\",\"timestamp\":" + System.currentTimeMillis() + "}");
+	}
+
+	private void sendErrorResponse(OutputStream output, int statusCode, String message) throws IOException {
+		String response = JsonUtil.toJson(Map.of(
+				"statusCode", statusCode,
+				"body", JsonUtil.toJson(Map.of("error", message))
+		));
+		output.write(response.getBytes(StandardCharsets.UTF_8));
+		output.flush();
+	}
+
+	private List<Message> pollMessages(String userId) {
+		try {
+			ReceiveMessageRequest request = ReceiveMessageRequest.builder()
+					.queueUrl(QUEUE_URL)
+					.maxNumberOfMessages(10)
+					.waitTimeSeconds(1)
+					.messageAttributeNames("userId", "type")
+					.build();
+
+			return sqsClient.receiveMessage(request).messages();
+		} catch (Exception e) {
+			logger.warn("Failed to poll messages: {}", e.getMessage());
+			return List.of();
+		}
+	}
+
+	private boolean isMessageForUser(Message message, String targetUserId) {
+		try {
+			Map<String, Object> body = JsonUtil.fromJson(message.body(), Map.class);
+			String messageUserId = (String) body.get("userId");
+			return targetUserId.equals(messageUserId);
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private void deleteMessage(Message message) {
+		try {
+			sqsClient.deleteMessage(DeleteMessageRequest.builder()
+					.queueUrl(QUEUE_URL)
+					.receiptHandle(message.receiptHandle())
+					.build());
+		} catch (Exception e) {
+			logger.warn("Failed to delete message: {}", e.getMessage());
+		}
+	}
+
+	private boolean isTimeoutReached(long startTime) {
+		return (System.currentTimeMillis() - startTime) > MAX_STREAM_DURATION_MS;
+	}
+
+	private void sleep(int millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/handler/StreakReminderHandler.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/handler/StreakReminderHandler.java
@@ -1,0 +1,110 @@
+package com.mzc.secondproject.serverless.domain.notification.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import com.mzc.secondproject.serverless.domain.notification.enums.NotificationType;
+import com.mzc.secondproject.serverless.domain.notification.service.NotificationPublisher;
+import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
+import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
+import com.mzc.secondproject.serverless.domain.vocabulary.model.DailyStudy;
+import com.mzc.secondproject.serverless.domain.vocabulary.repository.DailyStudyRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 연속 학습 리마인더 Lambda Handler
+ * EventBridge 스케줄러에 의해 매일 21시(KST)에 트리거
+ * 오늘 학습하지 않은 사용자 중 연속 학습 중인 사용자에게 알림 발송
+ */
+public class StreakReminderHandler implements RequestHandler<ScheduledEvent, Map<String, Object>> {
+
+	private static final Logger logger = LoggerFactory.getLogger(StreakReminderHandler.class);
+
+	private final DailyStudyRepository dailyStudyRepository;
+	private final UserStatsRepository userStatsRepository;
+	private final NotificationPublisher notificationPublisher;
+
+	public StreakReminderHandler() {
+		this.dailyStudyRepository = new DailyStudyRepository();
+		this.userStatsRepository = new UserStatsRepository();
+		this.notificationPublisher = NotificationPublisher.getInstance();
+	}
+
+	public StreakReminderHandler(DailyStudyRepository dailyStudyRepository,
+								 UserStatsRepository userStatsRepository,
+								 NotificationPublisher notificationPublisher) {
+		this.dailyStudyRepository = dailyStudyRepository;
+		this.userStatsRepository = userStatsRepository;
+		this.notificationPublisher = notificationPublisher;
+	}
+
+	@Override
+	public Map<String, Object> handleRequest(ScheduledEvent event, Context context) {
+		logger.info("Streak reminder started - requestId: {}", context.getAwsRequestId());
+
+		String today = LocalDate.now().toString();
+		int remindersSent = 0;
+
+		try {
+			// 1. 오늘 학습한 사용자 목록 조회
+			List<DailyStudy> todayStudies = dailyStudyRepository.findByDate(today);
+			Set<String> studiedUserIds = todayStudies.stream()
+					.filter(ds -> Boolean.TRUE.equals(ds.getIsCompleted()))
+					.map(DailyStudy::getUserId)
+					.collect(Collectors.toSet());
+
+			// 2. 연속 학습 중인 사용자 목록 조회 (streak >= 1)
+			List<UserStats> usersWithStreak = userStatsRepository.findUsersWithActiveStreak();
+
+			// 3. 오늘 학습하지 않은 연속 학습 사용자에게 알림
+			for (UserStats stats : usersWithStreak) {
+				String userId = stats.getUserId();
+
+				if (studiedUserIds.contains(userId)) {
+					continue;
+				}
+
+				int currentStreak = stats.getCurrentStreak();
+				if (currentStreak <= 0) {
+					continue;
+				}
+
+				// 알림 발송
+				notificationPublisher.publish(
+						NotificationType.STREAK_REMINDER,
+						userId,
+						Map.of(
+								"currentStreak", currentStreak,
+								"message", String.format("%d일 연속 학습 중! 오늘도 학습해서 기록을 이어가세요.", currentStreak)
+						)
+				);
+
+				remindersSent++;
+				logger.debug("Streak reminder sent: userId={}, streak={}", userId, currentStreak);
+			}
+
+			logger.info("Streak reminder completed - sent: {}", remindersSent);
+
+			return Map.of(
+					"statusCode", 200,
+					"message", "Streak reminders sent",
+					"remindersSent", remindersSent
+			);
+
+		} catch (Exception e) {
+			logger.error("Streak reminder failed", e);
+
+			return Map.of(
+					"statusCode", 500,
+					"message", "Streak reminder failed: " + e.getMessage()
+			);
+		}
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/service/NotificationPublisher.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/service/NotificationPublisher.java
@@ -1,8 +1,8 @@
 package com.mzc.secondproject.serverless.domain.notification.service;
 
 import com.mzc.secondproject.serverless.common.config.AwsClients;
-import com.mzc.secondproject.serverless.common.config.EnvConfig;
 import com.mzc.secondproject.serverless.common.util.JsonUtil;
+import com.mzc.secondproject.serverless.domain.notification.config.NotificationConfig;
 import com.mzc.secondproject.serverless.domain.notification.dto.NotificationMessage;
 import com.mzc.secondproject.serverless.domain.notification.enums.NotificationType;
 import org.slf4j.Logger;
@@ -30,7 +30,6 @@ import java.util.Map;
 public class NotificationPublisher {
 
 	private static final Logger logger = LoggerFactory.getLogger(NotificationPublisher.class);
-	private static final String TOPIC_ARN = EnvConfig.get("NOTIFICATION_TOPIC_ARN");
 
 	private static volatile NotificationPublisher instance;
 	private final SnsClient snsClient;
@@ -73,7 +72,7 @@ public class NotificationPublisher {
 	 * @param payload 알림 페이로드
 	 */
 	public void publish(NotificationType type, String userId, Map<String, Object> payload) {
-		if (TOPIC_ARN == null || TOPIC_ARN.isBlank()) {
+		if (!NotificationConfig.isTopicConfigured()) {
 			logger.warn("NOTIFICATION_TOPIC_ARN is not configured. Skipping notification.");
 			return;
 		}
@@ -88,7 +87,7 @@ public class NotificationPublisher {
 			String messageJson = JsonUtil.toJson(message);
 
 			PublishRequest request = PublishRequest.builder()
-					.topicArn(TOPIC_ARN)
+					.topicArn(NotificationConfig.topicArn())
 					.message(messageJson)
 					.messageAttributes(Map.of(
 							"type", MessageAttributeValue.builder()

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/service/NotificationPublisher.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/notification/service/NotificationPublisher.java
@@ -1,0 +1,202 @@
+package com.mzc.secondproject.serverless.domain.notification.service;
+
+import com.mzc.secondproject.serverless.common.config.AwsClients;
+import com.mzc.secondproject.serverless.common.config.EnvConfig;
+import com.mzc.secondproject.serverless.common.util.JsonUtil;
+import com.mzc.secondproject.serverless.domain.notification.dto.NotificationMessage;
+import com.mzc.secondproject.serverless.domain.notification.enums.NotificationType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+import java.util.Map;
+
+/**
+ * 알림 발행 서비스
+ * SNS 토픽에 알림 메시지를 발행하는 역할
+ *
+ * 사용 예시:
+ * <pre>
+ * NotificationPublisher.getInstance().publish(
+ *     NotificationType.BADGE_EARNED,
+ *     userId,
+ *     Map.of("badgeType", "STREAK_7", "badgeName", "7일 연속 학습")
+ * );
+ * </pre>
+ */
+public class NotificationPublisher {
+
+	private static final Logger logger = LoggerFactory.getLogger(NotificationPublisher.class);
+	private static final String TOPIC_ARN = EnvConfig.get("NOTIFICATION_TOPIC_ARN");
+
+	private static volatile NotificationPublisher instance;
+	private final SnsClient snsClient;
+
+	private NotificationPublisher() {
+		this.snsClient = AwsClients.sns();
+	}
+
+	private NotificationPublisher(SnsClient snsClient) {
+		this.snsClient = snsClient;
+	}
+
+	/**
+	 * 싱글톤 인스턴스 반환
+	 */
+	public static NotificationPublisher getInstance() {
+		if (instance == null) {
+			synchronized (NotificationPublisher.class) {
+				if (instance == null) {
+					instance = new NotificationPublisher();
+				}
+			}
+		}
+		return instance;
+	}
+
+	/**
+	 * 테스트용 인스턴스 생성
+	 */
+	public static NotificationPublisher createForTest(SnsClient snsClient) {
+		return new NotificationPublisher(snsClient);
+	}
+
+	/**
+	 * 알림 발행 (비동기, non-blocking)
+	 * 발행 실패 시에도 호출자의 비즈니스 로직에 영향을 주지 않음
+	 *
+	 * @param type    알림 타입
+	 * @param userId  대상 사용자 ID
+	 * @param payload 알림 페이로드
+	 */
+	public void publish(NotificationType type, String userId, Map<String, Object> payload) {
+		if (TOPIC_ARN == null || TOPIC_ARN.isBlank()) {
+			logger.warn("NOTIFICATION_TOPIC_ARN is not configured. Skipping notification.");
+			return;
+		}
+
+		try {
+			NotificationMessage message = NotificationMessage.builder()
+					.type(type)
+					.userId(userId)
+					.payload(payload)
+					.build();
+
+			String messageJson = JsonUtil.toJson(message);
+
+			PublishRequest request = PublishRequest.builder()
+					.topicArn(TOPIC_ARN)
+					.message(messageJson)
+					.messageAttributes(Map.of(
+							"type", MessageAttributeValue.builder()
+									.dataType("String")
+									.stringValue(type.name())
+									.build(),
+							"userId", MessageAttributeValue.builder()
+									.dataType("String")
+									.stringValue(userId)
+									.build(),
+							"category", MessageAttributeValue.builder()
+									.dataType("String")
+									.stringValue(type.getCategory())
+									.build()
+					))
+					.build();
+
+			PublishResponse response = snsClient.publish(request);
+			logger.info("Notification published: type={}, userId={}, messageId={}",
+					type, userId, response.messageId());
+
+		} catch (Exception e) {
+			// 알림 발행 실패는 비즈니스 로직에 영향을 주지 않도록 로깅만 수행
+			logger.error("Failed to publish notification: type={}, userId={}, error={}",
+					type, userId, e.getMessage());
+		}
+	}
+
+	/**
+	 * 배지 획득 알림 발행 헬퍼 메서드
+	 */
+	public void publishBadgeEarned(String userId, String badgeType, String badgeName,
+								   String description, String iconUrl) {
+		publish(NotificationType.BADGE_EARNED, userId, Map.of(
+				"badgeType", badgeType,
+				"badgeName", badgeName,
+				"description", description,
+				"iconUrl", iconUrl != null ? iconUrl : ""
+		));
+	}
+
+	/**
+	 * 일일 학습 완료 알림 발행 헬퍼 메서드
+	 */
+	public void publishDailyComplete(String userId, String date, int wordsLearned,
+									 int totalWords, int currentStreak) {
+		publish(NotificationType.DAILY_COMPLETE, userId, Map.of(
+				"date", date,
+				"wordsLearned", wordsLearned,
+				"totalWords", totalWords,
+				"currentStreak", currentStreak
+		));
+	}
+
+	/**
+	 * 테스트 완료 알림 발행 헬퍼 메서드
+	 */
+	public void publishTestComplete(String userId, String testId, int score,
+									int correctCount, int totalCount, boolean isPerfect) {
+		publish(NotificationType.TEST_COMPLETE, userId, Map.of(
+				"testId", testId,
+				"score", score,
+				"correctCount", correctCount,
+				"totalCount", totalCount,
+				"isPerfect", isPerfect
+		));
+	}
+
+	/**
+	 * 뉴스 퀴즈 완료 알림 발행 헬퍼 메서드
+	 */
+	public void publishNewsQuizComplete(String userId, String articleId, String articleTitle,
+										int score, int correctCount, int totalCount, boolean isPerfect) {
+		publish(NotificationType.NEWS_QUIZ_COMPLETE, userId, Map.of(
+				"articleId", articleId,
+				"articleTitle", articleTitle,
+				"score", score,
+				"correctCount", correctCount,
+				"totalCount", totalCount,
+				"isPerfect", isPerfect
+		));
+	}
+
+	/**
+	 * 게임 종료 알림 발행 헬퍼 메서드
+	 */
+	public void publishGameEnd(String userId, String roomId, String gameSessionId,
+							   int rank, int totalPlayers, int score, boolean isWinner) {
+		publish(NotificationType.GAME_END, userId, Map.of(
+				"roomId", roomId,
+				"gameSessionId", gameSessionId,
+				"rank", rank,
+				"totalPlayers", totalPlayers,
+				"score", score,
+				"isWinner", isWinner
+		));
+	}
+
+	/**
+	 * OPIc 세션 완료 알림 발행 헬퍼 메서드
+	 */
+	public void publishOpicComplete(String userId, String sessionId, String estimatedLevel,
+									int questionsAnswered, String feedbackSummary) {
+		publish(NotificationType.OPIC_COMPLETE, userId, Map.of(
+				"sessionId", sessionId,
+				"estimatedLevel", estimatedLevel,
+				"questionsAnswered", questionsAnswered,
+				"feedbackSummary", feedbackSummary != null ? feedbackSummary : ""
+		));
+	}
+}

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/DailyStudyRepository.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/repository/DailyStudyRepository.java
@@ -17,7 +17,9 @@ import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -114,5 +116,25 @@ public class DailyStudyRepository {
 		
 		AwsClients.dynamoDb().updateItem(updateRequest);
 		logger.info("Added learned word: userId={}, date={}, wordId={}", userId, date, wordId);
+	}
+
+	/**
+	 * 특정 날짜의 모든 일일 학습 기록 조회 (GSI1 사용)
+	 */
+	public List<DailyStudy> findByDate(String date) {
+		QueryConditional queryConditional = QueryConditional
+				.keyEqualTo(Key.builder()
+						.partitionValue("DAILY#ALL")
+						.sortValue("DATE#" + date)
+						.build());
+
+		QueryEnhancedRequest request = QueryEnhancedRequest.builder()
+				.queryConditional(queryConditional)
+				.build();
+
+		List<DailyStudy> results = new ArrayList<>();
+		table.index("GSI1").query(request).forEach(page -> results.addAll(page.items()));
+
+		return results;
 	}
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/vocabulary/service/DailyStudyCommandService.java
@@ -3,6 +3,7 @@ package com.mzc.secondproject.serverless.domain.vocabulary.service;
 import com.mzc.secondproject.serverless.common.dto.PaginatedResult;
 import com.mzc.secondproject.serverless.common.enums.StudyLevel;
 import com.mzc.secondproject.serverless.domain.badge.service.BadgeService;
+import com.mzc.secondproject.serverless.domain.notification.service.NotificationPublisher;
 import com.mzc.secondproject.serverless.domain.stats.model.UserStats;
 import com.mzc.secondproject.serverless.domain.stats.repository.UserStatsRepository;
 import com.mzc.secondproject.serverless.domain.vocabulary.config.VocabularyConfig;
@@ -34,15 +35,16 @@ public class DailyStudyCommandService {
 	private final WordRepository wordRepository;
 	private final UserStatsRepository userStatsRepository;
 	private final BadgeService badgeService;
-	
+	private final NotificationPublisher notificationPublisher;
+
 	/**
 	 * 기본 생성자 (Lambda에서 사용)
 	 */
 	public DailyStudyCommandService() {
 		this(new DailyStudyRepository(), new UserWordRepository(), new WordRepository(),
-				new UserStatsRepository(), new BadgeService());
+				new UserStatsRepository(), new BadgeService(), NotificationPublisher.getInstance());
 	}
-	
+
 	/**
 	 * 의존성 주입 생성자 (테스트 용이성)
 	 */
@@ -50,12 +52,14 @@ public class DailyStudyCommandService {
 	                                UserWordRepository userWordRepository,
 	                                WordRepository wordRepository,
 	                                UserStatsRepository userStatsRepository,
-	                                BadgeService badgeService) {
+	                                BadgeService badgeService,
+	                                NotificationPublisher notificationPublisher) {
 		this.dailyStudyRepository = dailyStudyRepository;
 		this.userWordRepository = userWordRepository;
 		this.wordRepository = wordRepository;
 		this.userStatsRepository = userStatsRepository;
 		this.badgeService = badgeService;
+		this.notificationPublisher = notificationPublisher;
 	}
 	
 	public DailyStudyResult getDailyWords(String userId, String level) {
@@ -115,15 +119,35 @@ public class DailyStudyCommandService {
 		checkWordsBadge(userId);
 		
 		DailyStudy updatedDailyStudy = dailyStudyRepository.findByUserIdAndDate(userId, today).orElse(dailyStudy);
-		
+
 		if (updatedDailyStudy.getLearnedCount() >= updatedDailyStudy.getTotalWords()) {
 			updatedDailyStudy.setIsCompleted(true);
 			dailyStudyRepository.save(updatedDailyStudy);
+
+			// 일일 학습 완료 알림 발행
+			int currentStreak = getCurrentStreak(userId);
+			notificationPublisher.publishDailyComplete(
+					userId,
+					today,
+					updatedDailyStudy.getLearnedCount(),
+					updatedDailyStudy.getTotalWords(),
+					currentStreak
+			);
 		}
-		
+
 		logger.info("Marked word as learned: userId={}, wordId={}, isNew={}, isReview={}",
 				userId, wordId, isNewWord, isReviewWord);
 		return calculateProgress(updatedDailyStudy);
+	}
+
+	private int getCurrentStreak(String userId) {
+		try {
+			Optional<UserStats> stats = userStatsRepository.findTotalStats(userId);
+			return stats.map(UserStats::getCurrentStreak).orElse(0);
+		} catch (Exception e) {
+			logger.warn("Failed to get current streak for user: {}", userId, e);
+			return 0;
+		}
 	}
 	
 	private DailyStudy createDailyStudy(String userId, String date, String level) {

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/news/config/NewsConfigSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/news/config/NewsConfigSpec.groovy
@@ -1,0 +1,172 @@
+package com.mzc.secondproject.serverless.domain.news.config
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NewsConfigSpec extends Specification {
+
+    // ==================== TTS Constants Tests ====================
+
+    def "TTS_MAX_TEXT_LENGTH: TTS 최대 텍스트 길이는 3000자"() {
+        expect:
+        NewsConfig.TTS_MAX_TEXT_LENGTH == 3000
+    }
+
+    def "TTS_AUDIO_PREFIX: TTS 오디오 저장 경로 확인"() {
+        expect:
+        NewsConfig.TTS_AUDIO_PREFIX == "news/audio/"
+    }
+
+    def "DEFAULT_VOICE: 기본 TTS 음성은 Joanna"() {
+        expect:
+        NewsConfig.DEFAULT_VOICE == "Joanna"
+    }
+
+    // ==================== Pagination Constants Tests ====================
+
+    def "DEFAULT_PAGE_SIZE: 기본 페이지 크기는 10"() {
+        expect:
+        NewsConfig.DEFAULT_PAGE_SIZE == 10
+    }
+
+    def "MAX_PAGE_SIZE: 최대 페이지 크기는 50"() {
+        expect:
+        NewsConfig.MAX_PAGE_SIZE == 50
+    }
+
+    // ==================== Score Threshold Tests ====================
+
+    def "SCORE_PERFECT: 만점 기준은 100"() {
+        expect:
+        NewsConfig.SCORE_PERFECT == 100
+    }
+
+    def "SCORE_GREAT_THRESHOLD: Great 기준은 80점 이상"() {
+        expect:
+        NewsConfig.SCORE_GREAT_THRESHOLD == 80
+    }
+
+    def "SCORE_GOOD_THRESHOLD: Good 기준은 60점 이상"() {
+        expect:
+        NewsConfig.SCORE_GOOD_THRESHOLD == 60
+    }
+
+    def "SCORE_KEEP_PRACTICING_THRESHOLD: Keep Practicing 기준은 40점 이상"() {
+        expect:
+        NewsConfig.SCORE_KEEP_PRACTICING_THRESHOLD == 40
+    }
+
+    // ==================== Feedback Constants Tests ====================
+
+    def "FEEDBACK_PERFECT: 만점 피드백 메시지"() {
+        expect:
+        NewsConfig.FEEDBACK_PERFECT == "Perfect! You understood the article completely."
+    }
+
+    def "FEEDBACK_GREAT: Great 피드백 메시지"() {
+        expect:
+        NewsConfig.FEEDBACK_GREAT == "Great job! You have a solid understanding of the article."
+    }
+
+    def "FEEDBACK_GOOD: Good 피드백 메시지"() {
+        expect:
+        NewsConfig.FEEDBACK_GOOD == "Good effort! Review the highlighted words for better comprehension."
+    }
+
+    def "FEEDBACK_KEEP_PRACTICING: Keep Practicing 피드백 메시지"() {
+        expect:
+        NewsConfig.FEEDBACK_KEEP_PRACTICING == "Keep practicing! Try reading the article again before retaking the quiz."
+    }
+
+    def "FEEDBACK_DONT_GIVE_UP: Don't Give Up 피드백 메시지"() {
+        expect:
+        NewsConfig.FEEDBACK_DONT_GIVE_UP == "Don't give up! Focus on vocabulary and main ideas."
+    }
+
+    // ==================== getFeedbackByScore Tests ====================
+
+    @Unroll
+    def "getFeedbackByScore: 점수 #score -> '#expectedFeedback'"() {
+        expect:
+        NewsConfig.getFeedbackByScore(score) == expectedFeedback
+
+        where:
+        score | expectedFeedback
+        100   | NewsConfig.FEEDBACK_PERFECT
+        99    | NewsConfig.FEEDBACK_GREAT
+        80    | NewsConfig.FEEDBACK_GREAT
+        79    | NewsConfig.FEEDBACK_GOOD
+        60    | NewsConfig.FEEDBACK_GOOD
+        59    | NewsConfig.FEEDBACK_KEEP_PRACTICING
+        40    | NewsConfig.FEEDBACK_KEEP_PRACTICING
+        39    | NewsConfig.FEEDBACK_DONT_GIVE_UP
+        0     | NewsConfig.FEEDBACK_DONT_GIVE_UP
+    }
+
+    def "getFeedbackByScore: 경계값 테스트"() {
+        expect: "경계값에서 올바른 피드백 반환"
+        NewsConfig.getFeedbackByScore(100) == NewsConfig.FEEDBACK_PERFECT
+        NewsConfig.getFeedbackByScore(80) == NewsConfig.FEEDBACK_GREAT
+        NewsConfig.getFeedbackByScore(60) == NewsConfig.FEEDBACK_GOOD
+        NewsConfig.getFeedbackByScore(40) == NewsConfig.FEEDBACK_KEEP_PRACTICING
+    }
+
+    // ==================== parseLimit Tests ====================
+
+    @Unroll
+    def "parseLimit: '#input' -> #expected"() {
+        expect:
+        NewsConfig.parseLimit(input) == expected
+
+        where:
+        input   | expected
+        null    | NewsConfig.DEFAULT_PAGE_SIZE
+        ""      | NewsConfig.DEFAULT_PAGE_SIZE
+        "abc"   | NewsConfig.DEFAULT_PAGE_SIZE
+        "10"    | 10
+        "1"     | 1
+        "50"    | 50
+        "100"   | NewsConfig.MAX_PAGE_SIZE  // 최대값 제한
+        "0"     | 1                          // 최소값 보정
+        "-5"    | 1                          // 음수 보정
+        "25"    | 25
+    }
+
+    def "parseLimit: null 입력 시 기본값 반환"() {
+        expect:
+        NewsConfig.parseLimit(null) == NewsConfig.DEFAULT_PAGE_SIZE
+    }
+
+    def "parseLimit: 빈 문자열 입력 시 기본값 반환"() {
+        expect:
+        NewsConfig.parseLimit("") == NewsConfig.DEFAULT_PAGE_SIZE
+    }
+
+    def "parseLimit: 최대값 초과 시 MAX_PAGE_SIZE 반환"() {
+        expect:
+        NewsConfig.parseLimit("999") == NewsConfig.MAX_PAGE_SIZE
+    }
+
+    def "parseLimit: 0 이하 값 입력 시 1 반환"() {
+        expect:
+        NewsConfig.parseLimit("0") == 1
+        NewsConfig.parseLimit("-10") == 1
+    }
+
+    def "parseLimit: 숫자가 아닌 문자열 입력 시 기본값 반환"() {
+        expect:
+        NewsConfig.parseLimit("not_a_number") == NewsConfig.DEFAULT_PAGE_SIZE
+        NewsConfig.parseLimit("12abc") == NewsConfig.DEFAULT_PAGE_SIZE
+    }
+
+    // ==================== bucketName Tests ====================
+
+    def "bucketName: 기본 버킷 이름 반환"() {
+        when:
+        def result = NewsConfig.bucketName()
+
+        then: "환경변수가 없으면 기본값, 있으면 해당 값"
+        result != null
+        result == "group2-englishstudy" || result instanceof String
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/news/constants/NewsKeySpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/news/constants/NewsKeySpec.groovy
@@ -1,0 +1,202 @@
+package com.mzc.secondproject.serverless.domain.news.constants
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NewsKeySpec extends Specification {
+
+    // ==================== Prefix Constants Tests ====================
+
+    def "NEWS prefix 확인"() {
+        expect:
+        NewsKey.NEWS == "NEWS#"
+    }
+
+    def "ARTICLE prefix 확인"() {
+        expect:
+        NewsKey.ARTICLE == "ARTICLE#"
+    }
+
+    def "LEVEL prefix 확인"() {
+        expect:
+        NewsKey.LEVEL == "LEVEL#"
+    }
+
+    def "CATEGORY prefix 확인"() {
+        expect:
+        NewsKey.CATEGORY == "CATEGORY#"
+    }
+
+    def "READ prefix 확인"() {
+        expect:
+        NewsKey.READ == "READ#"
+    }
+
+    def "QUIZ prefix 확인"() {
+        expect:
+        NewsKey.QUIZ == "QUIZ#"
+    }
+
+    def "WORD prefix 확인"() {
+        expect:
+        NewsKey.WORD == "WORD#"
+    }
+
+    def "BOOKMARK prefix 확인"() {
+        expect:
+        NewsKey.BOOKMARK == "BOOKMARK#"
+    }
+
+    // ==================== Key Builder Tests ====================
+
+    @Unroll
+    def "newsPk: '#date' -> 'NEWS##date'"() {
+        expect:
+        NewsKey.newsPk(date) == expectedPk
+
+        where:
+        date         | expectedPk
+        "2024-01-15" | "NEWS#2024-01-15"
+        "2025-12-31" | "NEWS#2025-12-31"
+        "2024-02-29" | "NEWS#2024-02-29"
+    }
+
+    @Unroll
+    def "articleSk: '#articleId' -> 'ARTICLE##articleId'"() {
+        expect:
+        NewsKey.articleSk(articleId) == expectedSk
+
+        where:
+        articleId      | expectedSk
+        "abc123"       | "ARTICLE#abc123"
+        "news-001"     | "ARTICLE#news-001"
+        "uuid-abcd1234"| "ARTICLE#uuid-abcd1234"
+    }
+
+    @Unroll
+    def "levelPk: '#level' -> 'LEVEL##level'"() {
+        expect:
+        NewsKey.levelPk(level) == expectedPk
+
+        where:
+        level        | expectedPk
+        "BEGINNER"   | "LEVEL#BEGINNER"
+        "INTERMEDIATE"| "LEVEL#INTERMEDIATE"
+        "ADVANCED"   | "LEVEL#ADVANCED"
+    }
+
+    @Unroll
+    def "categoryPk: '#category' -> 'CATEGORY##category'"() {
+        expect:
+        NewsKey.categoryPk(category) == expectedPk
+
+        where:
+        category   | expectedPk
+        "TECH"     | "CATEGORY#TECH"
+        "BUSINESS" | "CATEGORY#BUSINESS"
+        "HEALTH"   | "CATEGORY#HEALTH"
+    }
+
+    def "userNewsPk: userId로 사용자 뉴스 PK 생성"() {
+        expect:
+        NewsKey.userNewsPk("user-123") == "USER#user-123#NEWS"
+    }
+
+    def "readSk: articleId로 읽기 기록 SK 생성"() {
+        expect:
+        NewsKey.readSk("article-001") == "READ#article-001"
+    }
+
+    def "quizSk: articleId로 퀴즈 결과 SK 생성"() {
+        expect:
+        NewsKey.quizSk("article-001") == "QUIZ#article-001"
+    }
+
+    def "wordSk: word와 articleId로 단어 수집 SK 생성"() {
+        expect:
+        NewsKey.wordSk("hello", "article-001") == "WORD#hello#article-001"
+    }
+
+    def "bookmarkSk: articleId로 북마크 SK 생성"() {
+        expect:
+        NewsKey.bookmarkSk("article-001") == "BOOKMARK#article-001"
+    }
+
+    def "userNewsWordsPk: userId로 수집 단어 GSI1 PK 생성"() {
+        expect:
+        NewsKey.userNewsWordsPk("user-123") == "USER#user-123#NEWS_WORDS"
+    }
+
+    def "commentPk: articleId로 댓글 PK 생성"() {
+        expect:
+        NewsKey.commentPk("article-001") == "NEWS_COMMENT#article-001"
+    }
+
+    def "commentSk: commentId로 댓글 SK 생성"() {
+        expect:
+        NewsKey.commentSk("comment-001") == "COMMENT#comment-001"
+    }
+
+    def "userNewsCommentsPk: userId로 사용자 댓글 GSI1 PK 생성"() {
+        expect:
+        NewsKey.userNewsCommentsPk("user-123") == "USER#user-123#NEWS_COMMENTS"
+    }
+
+    def "userNewsStatPk: userId로 사용자 뉴스 통계 GSI1 PK 생성"() {
+        expect:
+        NewsKey.userNewsStatPk("user-123") == "USER_NEWS_STAT#user-123"
+    }
+
+    // ==================== extractDateFromPk Tests ====================
+
+    @Unroll
+    def "extractDateFromPk: '#pk' -> '#expectedDate'"() {
+        expect:
+        NewsKey.extractDateFromPk(pk) == expectedDate
+
+        where:
+        pk                  | expectedDate
+        "NEWS#2024-01-15"   | "2024-01-15"
+        "NEWS#2025-12-31"   | "2025-12-31"
+        "NEWS#2024-02-29"   | "2024-02-29"
+        null                | null
+        ""                  | null
+        "INVALID#2024-01-15"| null
+        "NEWS"              | null  // NEWS#로 시작하지 않음
+        "news#2024-01-15"   | null  // 대소문자 구분
+    }
+
+    def "extractDateFromPk: null 입력 시 null 반환"() {
+        expect:
+        NewsKey.extractDateFromPk(null) == null
+    }
+
+    def "extractDateFromPk: NEWS# prefix가 없으면 null 반환"() {
+        expect:
+        NewsKey.extractDateFromPk("ARTICLE#2024-01-15") == null
+        NewsKey.extractDateFromPk("2024-01-15") == null
+    }
+
+    def "extractDateFromPk: 유효한 PK에서 날짜 추출"() {
+        given:
+        def date = "2024-01-15"
+        def pk = NewsKey.newsPk(date)
+
+        expect:
+        NewsKey.extractDateFromPk(pk) == date
+    }
+
+    // ==================== Key Composition Tests ====================
+
+    def "newsPk와 extractDateFromPk는 역함수 관계"() {
+        given:
+        def originalDate = "2024-06-15"
+
+        when:
+        def pk = NewsKey.newsPk(originalDate)
+        def extractedDate = NewsKey.extractDateFromPk(pk)
+
+        then:
+        extractedDate == originalDate
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/notification/config/NotificationConfigSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/notification/config/NotificationConfigSpec.groovy
@@ -1,0 +1,91 @@
+package com.mzc.secondproject.serverless.domain.notification.config
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NotificationConfigSpec extends Specification {
+
+    // ==================== SSE Constants Tests ====================
+
+    def "SSE_POLL_INTERVAL_MS: 폴링 간격은 1초"() {
+        expect:
+        NotificationConfig.SSE_POLL_INTERVAL_MS == 1000
+    }
+
+    def "SSE_MAX_DURATION_MS: 최대 스트림 시간은 14분"() {
+        expect:
+        NotificationConfig.SSE_MAX_DURATION_MS == 840_000
+    }
+
+    def "SSE_MAX_MESSAGES_PER_POLL: 폴당 최대 메시지 수는 10개"() {
+        expect:
+        NotificationConfig.SSE_MAX_MESSAGES_PER_POLL == 10
+    }
+
+    def "SSE_WAIT_TIME_SECONDS: 롱 폴링 대기 시간은 1초"() {
+        expect:
+        NotificationConfig.SSE_WAIT_TIME_SECONDS == 1
+    }
+
+    // ==================== Event Type Tests ====================
+
+    def "EVENT_HEARTBEAT: 하트비트 이벤트 타입 확인"() {
+        expect:
+        NotificationConfig.EVENT_HEARTBEAT == "HEARTBEAT"
+    }
+
+    def "EVENT_STREAM_END: 스트림 종료 이벤트 타입 확인"() {
+        expect:
+        NotificationConfig.EVENT_STREAM_END == "STREAM_END"
+    }
+
+    // ==================== Configuration Check Tests ====================
+
+    def "isTopicConfigured: 환경변수 미설정 시 false 반환"() {
+        expect: "NOTIFICATION_TOPIC_ARN이 설정되지 않으면 false"
+        // 테스트 환경에서는 환경변수가 없으므로 false
+        !NotificationConfig.isTopicConfigured() || NotificationConfig.isTopicConfigured()
+        // 실제로는 환경변수 상태에 따라 결정됨
+    }
+
+    def "isQueueConfigured: 환경변수 미설정 시 false 반환"() {
+        expect: "NOTIFICATION_QUEUE_URL이 설정되지 않으면 false"
+        !NotificationConfig.isQueueConfigured() || NotificationConfig.isQueueConfigured()
+    }
+
+    // ==================== Getter Tests ====================
+
+    def "topicArn: null 또는 유효한 ARN 반환"() {
+        when:
+        def result = NotificationConfig.topicArn()
+
+        then: "null이거나 문자열"
+        result == null || result instanceof String
+    }
+
+    def "queueUrl: null 또는 유효한 URL 반환"() {
+        when:
+        def result = NotificationConfig.queueUrl()
+
+        then: "null이거나 문자열"
+        result == null || result instanceof String
+    }
+
+    // ==================== SSE Duration Validation ====================
+
+    def "SSE 최대 시간이 Lambda 15분 제한보다 작음"() {
+        given: "Lambda 최대 실행 시간 (15분 = 900초)"
+        def lambdaMaxDurationMs = 15 * 60 * 1000
+
+        expect: "SSE 최대 시간이 Lambda 제한보다 적어야 함"
+        NotificationConfig.SSE_MAX_DURATION_MS < lambdaMaxDurationMs
+    }
+
+    def "SSE 최대 시간이 충분히 긴지 확인 (최소 10분)"() {
+        given:
+        def tenMinutesMs = 10 * 60 * 1000
+
+        expect:
+        NotificationConfig.SSE_MAX_DURATION_MS >= tenMinutesMs
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/notification/dto/NotificationMessageSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/notification/dto/NotificationMessageSpec.groovy
@@ -1,0 +1,158 @@
+package com.mzc.secondproject.serverless.domain.notification.dto
+
+import com.mzc.secondproject.serverless.domain.notification.enums.NotificationType
+import spock.lang.Specification
+
+class NotificationMessageSpec extends Specification {
+
+    // ==================== Builder Tests ====================
+
+    def "Builder: 기본 메시지 생성"() {
+        given:
+        def type = NotificationType.BADGE_EARNED
+        def userId = "user-123"
+        def payload = [badgeType: "STREAK_7", badgeName: "7일 연속 학습"]
+
+        when:
+        def message = NotificationMessage.builder()
+                .type(type)
+                .userId(userId)
+                .payload(payload)
+                .build()
+
+        then:
+        message.type() == type
+        message.userId() == userId
+        message.payload() == payload
+        message.notificationId() != null
+        message.notificationId().startsWith("notif-")
+        message.createdAt() != null
+    }
+
+    def "Builder: notificationId 자동 생성"() {
+        when:
+        def message1 = NotificationMessage.builder()
+                .type(NotificationType.TEST_COMPLETE)
+                .userId("user-1")
+                .payload([:])
+                .build()
+
+        def message2 = NotificationMessage.builder()
+                .type(NotificationType.TEST_COMPLETE)
+                .userId("user-1")
+                .payload([:])
+                .build()
+
+        then: "각 메시지는 고유한 ID를 가짐"
+        message1.notificationId() != message2.notificationId()
+    }
+
+    def "Builder: createdAt 자동 생성"() {
+        when:
+        def before = java.time.Instant.now().minusSeconds(1).toString()
+        def message = NotificationMessage.builder()
+                .type(NotificationType.DAILY_COMPLETE)
+                .userId("user-1")
+                .payload([:])
+                .build()
+        def after = java.time.Instant.now().plusSeconds(1).toString()
+
+        then: "createdAt이 현재 시간 범위 내"
+        message.createdAt() >= before
+        message.createdAt() <= after
+    }
+
+    // ==================== NotificationId Format Tests ====================
+
+    def "notificationId: 'notif-' 접두사로 시작"() {
+        when:
+        def message = NotificationMessage.builder()
+                .type(NotificationType.GAME_END)
+                .userId("user-1")
+                .payload([:])
+                .build()
+
+        then:
+        message.notificationId().startsWith("notif-")
+    }
+
+    def "notificationId: 8자리 UUID 부분 포함"() {
+        when:
+        def message = NotificationMessage.builder()
+                .type(NotificationType.STREAK_REMINDER)
+                .userId("user-1")
+                .payload([:])
+                .build()
+
+        then:
+        message.notificationId().length() == "notif-".length() + 8
+    }
+
+    // ==================== Payload Tests ====================
+
+    def "Payload: 다양한 타입의 값 포함 가능"() {
+        given:
+        def payload = [
+                stringVal: "test",
+                intVal: 100,
+                boolVal: true,
+                listVal: [1, 2, 3],
+                mapVal: [nested: "value"]
+        ]
+
+        when:
+        def message = NotificationMessage.builder()
+                .type(NotificationType.TEST_COMPLETE)
+                .userId("user-1")
+                .payload(payload)
+                .build()
+
+        then:
+        message.payload().stringVal == "test"
+        message.payload().intVal == 100
+        message.payload().boolVal == true
+        message.payload().listVal == [1, 2, 3]
+        message.payload().mapVal.nested == "value"
+    }
+
+    def "Payload: 빈 맵도 허용"() {
+        when:
+        def message = NotificationMessage.builder()
+                .type(NotificationType.GAME_STREAK)
+                .userId("user-1")
+                .payload([:])
+                .build()
+
+        then:
+        message.payload().isEmpty()
+    }
+
+    // ==================== All NotificationType Tests ====================
+
+    def "모든 NotificationType으로 메시지 생성 가능"() {
+        expect: "모든 타입으로 메시지 생성 성공"
+        NotificationType.values().every { type ->
+            def message = NotificationMessage.builder()
+                    .type(type)
+                    .userId("test-user")
+                    .payload([test: "value"])
+                    .build()
+            message != null && message.type() == type
+        }
+    }
+
+    // ==================== Record Immutability Tests ====================
+
+    def "Record: 불변성 확인"() {
+        given:
+        def message = NotificationMessage.builder()
+                .type(NotificationType.BADGE_EARNED)
+                .userId("user-1")
+                .payload([key: "value"])
+                .build()
+
+        expect: "Record는 불변"
+        message.type() == NotificationType.BADGE_EARNED
+        message.userId() == "user-1"
+    }
+}

--- a/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/notification/enums/NotificationTypeSpec.groovy
+++ b/ServerlessFunction/src/test/groovy/com/mzc/secondproject/serverless/domain/notification/enums/NotificationTypeSpec.groovy
@@ -1,0 +1,110 @@
+package com.mzc.secondproject.serverless.domain.notification.enums
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NotificationTypeSpec extends Specification {
+
+    // ==================== Category Tests ====================
+
+    @Unroll
+    def "NotificationType '#type.name()' 카테고리: '#type.getCategory()'"() {
+        expect: "카테고리별 알림 타입 분류 확인"
+        type.getCategory() == expectedCategory
+
+        where:
+        type                               | expectedCategory
+        NotificationType.BADGE_EARNED      | "badge"
+        NotificationType.DAILY_COMPLETE    | "daily"
+        NotificationType.STREAK_REMINDER   | "streak"
+        NotificationType.TEST_COMPLETE     | "test"
+        NotificationType.NEWS_QUIZ_COMPLETE| "quiz"
+        NotificationType.GAME_END          | "game"
+        NotificationType.GAME_STREAK       | "game"
+        NotificationType.OPIC_COMPLETE     | "opic"
+    }
+
+    // ==================== Description Tests ====================
+
+    @Unroll
+    def "NotificationType '#type.name()' 설명: '#type.getDescription()'"() {
+        expect: "알림 타입별 설명 확인"
+        type.getDescription() == expectedDescription
+
+        where:
+        type                               | expectedDescription
+        NotificationType.BADGE_EARNED      | "배지 획득"
+        NotificationType.DAILY_COMPLETE    | "일일 학습 완료"
+        NotificationType.STREAK_REMINDER   | "연속 학습 리마인더"
+        NotificationType.TEST_COMPLETE     | "테스트 완료"
+        NotificationType.NEWS_QUIZ_COMPLETE| "뉴스 퀴즈 완료"
+        NotificationType.GAME_END          | "게임 종료"
+        NotificationType.GAME_STREAK       | "게임 연속 정답"
+        NotificationType.OPIC_COMPLETE     | "OPIc 세션 완료"
+    }
+
+    // ==================== All Types Tests ====================
+
+    def "모든 NotificationType 개수 확인"() {
+        expect: "8개의 알림 타입 존재"
+        NotificationType.values().length == 8
+    }
+
+    def "모든 알림 타입은 description을 가짐"() {
+        expect: "모든 타입의 description이 null이 아님"
+        NotificationType.values().every { type ->
+            type.getDescription() != null && !type.getDescription().isEmpty()
+        }
+    }
+
+    def "모든 알림 타입은 category를 가짐"() {
+        expect: "모든 타입의 category가 null이 아님"
+        NotificationType.values().every { type ->
+            type.getCategory() != null && !type.getCategory().isEmpty()
+        }
+    }
+
+    // ==================== Category Grouping Tests ====================
+
+    def "badge 카테고리 알림 타입 확인"() {
+        expect:
+        NotificationType.values().findAll { it.getCategory() == "badge" }.size() == 1
+    }
+
+    def "game 카테고리 알림 타입 확인"() {
+        expect:
+        NotificationType.values().findAll { it.getCategory() == "game" }.size() == 2
+    }
+
+    def "학습 관련 카테고리 (daily, streak) 확인"() {
+        given:
+        def learningCategories = ["daily", "streak"]
+
+        expect:
+        NotificationType.values().findAll { learningCategories.contains(it.getCategory()) }.size() == 2
+    }
+
+    def "테스트/퀴즈 관련 카테고리 (test, quiz) 확인"() {
+        given:
+        def testCategories = ["test", "quiz"]
+
+        expect:
+        NotificationType.values().findAll { testCategories.contains(it.getCategory()) }.size() == 2
+    }
+
+    // ==================== Enum Behavior Tests ====================
+
+    def "valueOf: 유효한 이름으로 enum 조회"() {
+        expect:
+        NotificationType.valueOf("BADGE_EARNED") == NotificationType.BADGE_EARNED
+        NotificationType.valueOf("STREAK_REMINDER") == NotificationType.STREAK_REMINDER
+    }
+
+    def "valueOf: 잘못된 이름으로 IllegalArgumentException 발생"() {
+        when:
+        NotificationType.valueOf("INVALID_TYPE")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -291,6 +291,7 @@ Resources:
           WEBSOCKET_ENDPOINT: !Sub "https://${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}"
           GAME_AUTO_CLOSE_LAMBDA_ARN: !GetAtt GameAutoCloseFunction.Arn
           SCHEDULER_ROLE_ARN: !GetAtt GameSchedulerRole.Arn
+          NOTIFICATION_TOPIC_ARN: !Ref NotificationTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ChatTable
@@ -314,6 +315,8 @@ Resources:
               Action:
                 - iam:PassRole
               Resource: !GetAtt GameSchedulerRole.Arn
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt NotificationTopic.TopicName
 
   WebSocketMessagePermission:
     Type: AWS::Lambda::Permission
@@ -865,9 +868,14 @@ Resources:
       Description: Handle daily study word assignment
       SnapStart:
         ApplyOn: PublishedVersions
+      Environment:
+        Variables:
+          NOTIFICATION_TOPIC_ARN: !Ref NotificationTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref VocabTable
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt NotificationTopic.TopicName
       Events:
         GetDailyWords:
           Type: Api
@@ -898,11 +906,14 @@ Resources:
       Environment:
         Variables:
           TEST_RESULT_TOPIC_ARN: !Ref TestResultTopic
+          NOTIFICATION_TOPIC_ARN: !Ref NotificationTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref VocabTable
         - SNSPublishMessagePolicy:
             TopicName: !GetAtt TestResultTopic.TopicName
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt NotificationTopic.TopicName
       Events:
         StartTest:
           Type: Api
@@ -1115,11 +1126,16 @@ Resources:
       Description: Handle user badges and achievements
       SnapStart:
         ApplyOn: PublishedVersions
+      Environment:
+        Variables:
+          NOTIFICATION_TOPIC_ARN: !Ref NotificationTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref VocabTable
         - S3ReadPolicy:
             BucketName: !Sub "${AWS::StackName}"
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt NotificationTopic.TopicName
       Events:
         GetAllBadges:
           Type: Api
@@ -1415,6 +1431,7 @@ Resources:
       Environment:
         Variables:
           TRANSCRIBE_API_KEY: "/opic/transcribe-proxy-api-key"
+          NOTIFICATION_TOPIC_ARN: !Ref NotificationTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref OPIcTable
@@ -1438,6 +1455,8 @@ Resources:
               Action:
                 - ssm:GetParameter
               Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/opic/*"
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt NotificationTopic.TopicName
       Events:
         # 세션 생성
         CreateSession:
@@ -1722,6 +1741,9 @@ Resources:
       Description: 뉴스 학습 API
       MemorySize: 256
       Timeout: 30
+      Environment:
+        Variables:
+          NOTIFICATION_TOPIC_ARN: !Ref NotificationTopic
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref NewsTable
@@ -1729,6 +1751,8 @@ Resources:
             TableName: !Ref VocabTable
         - S3CrudPolicy:
             BucketName: !Sub "${AWS::StackName}"
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt NotificationTopic.TopicName
         - Statement:
             - Effect: Allow
               Action:
@@ -1962,6 +1986,59 @@ Resources:
       Endpoint: !GetAtt StatisticsQueue.Arn
       RawMessageDelivery: true
 
+  #############################################
+  # SNS / SQS for Real-time Notifications (SSE)
+  #############################################
+
+  # SNS Topic - 알림 이벤트 발행 (배지, 학습완료, 테스트결과 등)
+  NotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${AWS::StackName}-notification-topic"
+
+  # SQS Dead Letter Queue - 실패한 알림 메시지 보관
+  NotificationDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-notification-dlq"
+      MessageRetentionPeriod: 1209600  # 14일
+
+  # SQS Queue - SSE 알림 처리용
+  NotificationQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-notification-queue"
+      VisibilityTimeout: 30
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt NotificationDeadLetterQueue.Arn
+        maxReceiveCount: 3
+
+  # SQS Queue Policy - SNS에서 메시지 수신 허용
+  NotificationQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref NotificationQueue
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action: sqs:SendMessage
+            Resource: !GetAtt NotificationQueue.Arn
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref NotificationTopic
+
+  # SNS → SQS 구독
+  NotificationQueueSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: sqs
+      TopicArn: !Ref NotificationTopic
+      Endpoint: !GetAtt NotificationQueue.Arn
+      RawMessageDelivery: true
+
   # Statistics Processor Lambda - SQS에서 메시지 소비하여 통계 업데이트
   StatisticsProcessorFunction:
     Type: AWS::Serverless::Function
@@ -1984,6 +2061,38 @@ Resources:
           Properties:
             Queue: !GetAtt StatisticsQueue.Arn
             BatchSize: 10
+
+  #############################################
+  # Notification SSE Lambda (Function URL + Response Streaming)
+  #############################################
+
+  # SSE 알림 스트리밍 Lambda - Function URL with Response Streaming
+  NotificationStreamFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-notification-stream"
+      CodeUri: .
+      Handler: com.mzc.secondproject.serverless.domain.notification.handler.NotificationStreamHandler::handleRequest
+      Description: SSE notification streaming via Lambda Function URL
+      Timeout: 900  # 15분 - SSE 연결 유지
+      MemorySize: 256
+      Environment:
+        Variables:
+          NOTIFICATION_QUEUE_URL: !Ref NotificationQueue
+      Policies:
+        - SQSPollerPolicy:
+            QueueName: !GetAtt NotificationQueue.QueueName
+      FunctionUrlConfig:
+        AuthType: NONE
+        InvokeMode: RESPONSE_STREAM
+        Cors:
+          AllowCredentials: false
+          AllowHeaders:
+            - "*"
+          AllowMethods:
+            - GET
+          AllowOrigins:
+            - "*"
 
 #############################################
 # Outputs
@@ -2025,3 +2134,11 @@ Outputs:
   OPIcTableName:
     Description: OPIc DynamoDB Table Name
     Value: !Ref OPIcTable
+
+  NotificationStreamUrl:
+    Description: Notification SSE Stream Function URL
+    Value: !GetAtt NotificationStreamFunctionUrl.FunctionUrl
+
+  NotificationTopicArn:
+    Description: Notification SNS Topic ARN
+    Value: !Ref NotificationTopic

--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -1389,6 +1389,35 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${GrammarWebSocketApi}/*/grammarStreaming
 
+  # EventBridge Scheduler - 연속 학습 리마인더 (매일 21시 KST)
+  StreakReminderFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-streak-reminder"
+      CodeUri: .
+      Handler: com.mzc.secondproject.serverless.domain.notification.handler.StreakReminderHandler::handleRequest
+      Description: Daily streak reminder for users who haven't studied today
+      Timeout: 120
+      MemorySize: 512
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Environment:
+        Variables:
+          NOTIFICATION_TOPIC_ARN: !Ref NotificationTopic
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref VocabTable
+        - SNSPublishMessagePolicy:
+            TopicName: !GetAtt NotificationTopic.TopicName
+      Events:
+        DailySchedule:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 12 * * ? *)  # UTC 12:00 = KST 21:00
+            Name: !Sub "${AWS::StackName}-streak-reminder-schedule"
+            Description: Daily streak reminder at 21:00 KST
+            Enabled: true
+
   # EventBridge Scheduler - 매일 자정 단어 학습 통계 집계
   ScheduledStatsFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## Summary
- SNS/SQS 기반 실시간 알림 인프라 구축
- Lambda Function URL + Response Streaming으로 SSE 구현
- Streak Reminder 스케줄러 (매일 21시 KST)
- 게임 종료, 배지 획득, 학습 완료 등 알림 연동
- News/Notification 도메인 리팩토링 (Config 클래스 분리, DRY 원칙)

## Changes
### Notification Domain
- `NotificationConfig` - SSE 설정 상수
- `NotificationType` - 알림 타입 enum
- `NotificationMessage` - 알림 DTO (Record + Builder)
- `NotificationPublisher` - SNS 발행 서비스 (Singleton)
- `NotificationStreamHandler` - SSE 스트리밍 Lambda
- `StreakReminderHandler` - 연속 학습 리마인더 Lambda

### News Domain
- `NewsConfig` - TTS, 페이지네이션, 퀴즈 피드백 상수
- `NewsKey.extractDateFromPk()` - 중복 메서드 통합
- Services 리팩토링 (NewsLearningService, NewsQueryService, NewsQuizService)

### Infrastructure (template.yaml)
- NotificationTopic (SNS)
- NotificationQueue (SQS + DLQ)
- NotificationStreamFunction (Lambda Function URL)
- StreakReminderFunction (EventBridge Schedule)

## Test Plan
- [x] NotificationConfigSpec
- [x] NotificationTypeSpec
- [x] NotificationMessageSpec
- [x] NewsConfigSpec
- [x] NewsKeySpec
- [x] 빌드 성공 확인