### PR TITLE
fix: add UserTable read permission to WebSocket Lambda

### DIFF
--- a/ServerlessFunction/template.yaml
+++ b/ServerlessFunction/template.yaml
@@ -297,6 +297,8 @@ Resources:
             TableName: !Ref ChatTable
         - DynamoDBCrudPolicy:
             TableName: !Ref VocabTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref UserTable
         - Statement:
             - Effect: Allow
               Action:


### PR DESCRIPTION
## Summary
- WebSocket Lambda(채팅 메시지 핸들러)에 UserTable 읽기 권한 추가
- `/member`, `/dice`, `/coin`, `/hint` 등 채팅 명령어에서 닉네임 조회를 위해 UserTable 접근이 필요

## Root Cause
`WebSocketMessageFunction`이 `UserTable`에 대한 `DynamoDBReadPolicy`가 없어서 채팅 명령어 처리 시 닉네임 조회가 실패

## Fix
```yaml
- DynamoDBReadPolicy:
    TableName: !Ref UserTable
```

## Test plan
- [ ] 배포 후 `/member` 명령어 테스트
- [ ] 배포 후 `/dice` 명령어 테스트
- [ ] 배포 후 `/coin` 명령어 테스트
