### PR TITLE
fix: Cognito 파라미터 CI/CD 배포 설정 및 끝말잇기 턴시간 설정 지원

### DIFF
--- a/ServerlessFunction/buildspec-dev.yml
+++ b/ServerlessFunction/buildspec-dev.yml
@@ -43,7 +43,10 @@ phases:
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --no-confirm-changeset \
           --no-fail-on-empty-changeset \
-          --parameter-overrides Environment=$ENVIRONMENT
+          --parameter-overrides \
+            Environment=$ENVIRONMENT \
+            ExistingCognitoUserPoolId=ap-northeast-2_ezDwzFCzR \
+            ExistingCognitoClientId=4ns077jcr1pkue2vvisr6qdpu5
       - echo "Deployment completed on $(date)"
 
 cache:

--- a/ServerlessFunction/buildspec-prod.yml
+++ b/ServerlessFunction/buildspec-prod.yml
@@ -43,7 +43,10 @@ phases:
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --no-confirm-changeset \
           --no-fail-on-empty-changeset \
-          --parameter-overrides Environment=$ENVIRONMENT
+          --parameter-overrides \
+            Environment=$ENVIRONMENT \
+            ExistingCognitoUserPoolId=ap-northeast-2_ezDwzFCzR \
+            ExistingCognitoClientId=4ns077jcr1pkue2vvisr6qdpu5
       - echo "Deployment completed on $(date)"
 
 cache:

--- a/ServerlessFunction/buildspec-test.yml
+++ b/ServerlessFunction/buildspec-test.yml
@@ -43,7 +43,7 @@ phases:
           --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
           --no-confirm-changeset \
           --no-fail-on-empty-changeset \
-          --parameter-overrides Environment=$ENVIRONMENT
+          --parameter-overrides Environment=$ENVIRONMENT ExistingCognitoUserPoolId=ap-northeast-2_ezDwzFCzR ExistingCognitoClientId=4ns077jcr1pkue2vvisr6qdpu5
       - echo "Deployment completed on $(date)"
 
 cache:

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameSettings.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/GameSettings.java
@@ -14,10 +14,13 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 public class GameSettings {
 	@Builder.Default
 	private Integer maxRounds = 5;
-	
+
 	@Builder.Default
 	private Integer roundTimeLimit = 60;
-	
+
+	@Builder.Default
+	private Integer turnTimeLimit = 15;  // 끝말잇기용 턴 시간 제한
+
 	@Builder.Default
 	private Boolean autoDeleteOnEnd = false;
 }

--- a/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/WordChainSession.java
+++ b/ServerlessFunction/src/main/java/com/mzc/secondproject/serverless/domain/chatting/model/WordChainSession.java
@@ -40,6 +40,7 @@ public class WordChainSession {
 	private Character nextLetter;   // 다음 사람이 시작해야 할 글자
 	private Long turnStartTime;
 	private Integer timeLimit;      // 현재 라운드 시간 제한 (초)
+	private Integer baseTurnTimeLimit; // 사용자 설정 기본 턴 시간 (초)
 
 	// 플레이어 관리
 	private List<String> players;           // 전체 플레이어 (순서대로)
@@ -182,10 +183,27 @@ public class WordChainSession {
 
 	/**
 	 * 시간 제한 계산 (라운드에 따라 점점 빨라짐)
-	 * Round 1-2: 15초, Round 3-4: 13초, Round 5-6: 11초, Round 7-8: 9초, Round 9+: 8초
+	 * 기본값 15초에서 시작하여 2라운드마다 2초씩 감소, 최소 8초
 	 */
 	public static int calculateTimeLimit(int round) {
-		return Math.max(8, 15 - ((round - 1) / 2) * 2);
+		return calculateTimeLimit(round, 15);
+	}
+
+	/**
+	 * 시간 제한 계산 (기본 시간 제한 기준)
+	 * 설정된 기본 시간에서 시작하여 2라운드마다 1초씩 감소, 최소 (baseTimeLimit / 2)초
+	 */
+	public static int calculateTimeLimit(int round, int baseTimeLimit) {
+		int minTimeLimit = Math.max(5, baseTimeLimit / 2);
+		return Math.max(minTimeLimit, baseTimeLimit - ((round - 1) / 2));
+	}
+
+	/**
+	 * 세션의 기본 시간 제한을 기준으로 다음 라운드 시간 계산
+	 */
+	public int getNextRoundTimeLimit(int nextRound) {
+		int base = baseTurnTimeLimit != null ? baseTurnTimeLimit : 15;
+		return calculateTimeLimit(nextRound, base);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- CI/CD 배포 시 Cognito User Pool 파라미터가 누락되어 401 에러가 발생하던 문제 해결
- 끝말잇기 게임에서 방 설정의 turnTimeLimit을 사용하도록 수정

## Changes
- `buildspec-dev.yml`, `buildspec-prod.yml`: ExistingCognitoUserPoolId, ExistingCognitoClientId 파라미터 추가
- `GameSettings.java`: turnTimeLimit 필드 추가
- `WordChainSession.java`: baseTurnTimeLimit 필드 및 시간 계산 메서드 추가
- `WordChainService.java`: ChatRoomRepository를 통해 방의 gameSettings에서 turnTimeLimit 조회

## Test plan
- [ ] dev 환경 배포 후 401 에러 발생하지 않는지 확인
- [ ] 끝말잇기 게임 시작 시 설정된 턴 시간이 적용되는지 확인